### PR TITLE
Refactor: Migrate CLI scripts from argparse to click with comprehensive tests

### DIFF
--- a/packages/pitlane-agent/pyproject.toml
+++ b/packages/pitlane-agent/pyproject.toml
@@ -5,10 +5,14 @@ description = "AI agent for F1 data analysis using Claude Agent SDK and FastF1"
 requires-python = ">=3.11"
 dependencies = [
     "claude-agent-sdk",
+    "click>=8.1.0",
     "fastf1>=3.0",
     "matplotlib>=3.8",
     "numpy>=1.24",
 ]
+
+[project.scripts]
+pitlane = "pitlane_agent.cli:pitlane"
 
 [build-system]
 requires = ["hatchling"]
@@ -16,3 +20,14 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/pitlane_agent"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+addopts = [
+    "--strict-markers",
+    "--strict-config",
+    "-ra",
+]

--- a/packages/pitlane-agent/src/pitlane_agent/cli.py
+++ b/packages/pitlane-agent/src/pitlane_agent/cli.py
@@ -1,0 +1,30 @@
+"""PitLane AI CLI - Unified command interface for F1 data analysis tools.
+
+Usage:
+    pitlane --help
+    pitlane session-info --year 2024 --gp Monaco --session R
+    pitlane lap-times --year 2024 --gp Monaco --session Q --drivers VER --drivers HAM
+    pitlane tyre-strategy --year 2024 --gp Monaco --session R
+"""
+
+import click
+
+from pitlane_agent.scripts.lap_times import cli as lap_times_cli
+from pitlane_agent.scripts.session_info import cli as session_info_cli
+from pitlane_agent.scripts.tyre_strategy import cli as tyre_strategy_cli
+
+
+@click.group()
+def pitlane():
+    """PitLane AI - F1 data analysis tools powered by FastF1 and Claude."""
+    pass
+
+
+# Register subcommands
+pitlane.add_command(lap_times_cli, name="lap-times")
+pitlane.add_command(session_info_cli, name="session-info")
+pitlane.add_command(tyre_strategy_cli, name="tyre-strategy")
+
+
+if __name__ == "__main__":
+    pitlane()

--- a/packages/pitlane-agent/src/pitlane_agent/scripts/session_info.py
+++ b/packages/pitlane-agent/src/pitlane_agent/scripts/session_info.py
@@ -1,13 +1,16 @@
 """Get F1 session information from FastF1.
 
 Usage:
+    pitlane session-info --year 2024 --gp Monaco --session R
+
+    # Or using module invocation
     python -m pitlane_agent.scripts.session_info --year 2024 --gp Monaco --session R
 """
 
-import argparse
 import json
 import sys
 
+import click
 import fastf1
 
 
@@ -54,26 +57,34 @@ def get_session_info(year: int, gp: str, session_type: str) -> dict:
     }
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Get F1 session information")
-    parser.add_argument("--year", type=int, required=True, help="Season year (e.g., 2024)")
-    parser.add_argument("--gp", type=str, required=True, help="Grand Prix name (e.g., Monaco)")
-    parser.add_argument(
-        "--session",
-        type=str,
-        required=True,
-        help="Session type: R (Race), Q (Qualifying), FP1, FP2, FP3, S (Sprint), SQ",
-    )
-
-    args = parser.parse_args()
-
+@click.command()
+@click.option(
+    "--year",
+    type=int,
+    required=True,
+    help="Season year (e.g., 2024)"
+)
+@click.option(
+    "--gp",
+    type=str,
+    required=True,
+    help="Grand Prix name (e.g., Monaco, Silverstone)"
+)
+@click.option(
+    "--session",
+    type=str,
+    required=True,
+    help="Session type: R (Race), Q (Qualifying), FP1, FP2, FP3, S (Sprint), SQ"
+)
+def cli(year, gp, session):
+    """Get F1 session information including drivers and metadata."""
     try:
-        info = get_session_info(args.year, args.gp, args.session)
-        print(json.dumps(info, indent=2))
+        info = get_session_info(year, gp, session)
+        click.echo(json.dumps(info, indent=2))
     except Exception as e:
-        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        click.echo(json.dumps({"error": str(e)}), err=True)
         sys.exit(1)
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/packages/pitlane-agent/src/pitlane_agent/scripts/tyre_strategy.py
+++ b/packages/pitlane-agent/src/pitlane_agent/scripts/tyre_strategy.py
@@ -1,16 +1,19 @@
 """Generate tyre strategy visualization from FastF1 data.
 
 Usage:
+    pitlane tyre-strategy --year 2024 --gp Monaco --session R
+
+    # Or using module invocation
     python -m pitlane_agent.scripts.tyre_strategy \
         --year 2024 --gp Monaco --session R \
         --output /tmp/pitlane_charts/tyre_strategy.png
 """
 
-import argparse
 import json
 import sys
 from pathlib import Path
 
+import click
 import fastf1
 import fastf1.plotting
 import matplotlib.pyplot as plt
@@ -191,37 +194,45 @@ def generate_tyre_strategy_chart(
     }
 
 
-def main():
-    parser = argparse.ArgumentParser(description="Generate tyre strategy chart")
-    parser.add_argument("--year", type=int, required=True, help="Season year")
-    parser.add_argument("--gp", type=str, required=True, help="Grand Prix name")
-    parser.add_argument(
-        "--session",
-        type=str,
-        default="R",
-        help="Session type (default: R for Race)",
-    )
-    parser.add_argument(
-        "--output",
-        type=str,
-        default="/tmp/pitlane_charts/tyre_strategy.png",
-        help="Output path for the chart",
-    )
-
-    args = parser.parse_args()
-
+@click.command()
+@click.option(
+    "--year",
+    type=int,
+    required=True,
+    help="Season year (e.g., 2024)"
+)
+@click.option(
+    "--gp",
+    type=str,
+    required=True,
+    help="Grand Prix name (e.g., Monaco, Silverstone)"
+)
+@click.option(
+    "--session",
+    type=str,
+    default="R",
+    help="Session type (default: R for Race)"
+)
+@click.option(
+    "--output",
+    type=click.Path(),
+    default="/tmp/pitlane_charts/tyre_strategy.png",
+    help="Output path for the chart image"
+)
+def cli(year, gp, session, output):
+    """Generate tyre strategy visualization for a race."""
     try:
         result = generate_tyre_strategy_chart(
-            year=args.year,
-            gp=args.gp,
-            session_type=args.session,
-            output_path=args.output,
+            year=year,
+            gp=gp,
+            session_type=session,
+            output_path=output,
         )
-        print(json.dumps(result, indent=2))
+        click.echo(json.dumps(result, indent=2))
     except Exception as e:
-        print(json.dumps({"error": str(e)}), file=sys.stderr)
+        click.echo(json.dumps({"error": str(e)}), err=True)
         sys.exit(1)
 
 
 if __name__ == "__main__":
-    main()
+    cli()

--- a/packages/pitlane-agent/tests/__init__.py
+++ b/packages/pitlane-agent/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pitlane-agent package."""

--- a/packages/pitlane-agent/tests/conftest.py
+++ b/packages/pitlane-agent/tests/conftest.py
@@ -1,0 +1,44 @@
+"""Pytest configuration and shared fixtures for pitlane-agent tests."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def tmp_output_dir(tmp_path):
+    """Provide a temporary directory for chart output."""
+    output_dir = tmp_path / "charts"
+    output_dir.mkdir()
+    return output_dir
+
+
+@pytest.fixture
+def mock_fastf1_session():
+    """Mock FastF1 session object."""
+    session = MagicMock()
+    session.event = {"EventName": "Monaco Grand Prix", "Country": "Monaco"}
+    session.name = "Qualifying"
+    session.date = MagicMock()
+    session.date.date.return_value = "2024-05-25"
+    session.total_laps = 78
+    return session
+
+
+@pytest.fixture
+def mock_fastf1_cache(monkeypatch):
+    """Mock FastF1 cache to prevent actual caching."""
+    mock_cache = MagicMock()
+    monkeypatch.setattr("fastf1.Cache.enable_cache", mock_cache)
+    return mock_cache
+
+
+@pytest.fixture
+def sample_driver_data():
+    """Sample driver data for testing."""
+    return {
+        "drivers": ["VER", "HAM", "LEC"],
+        "year": 2024,
+        "gp": "Monaco",
+        "session": "Q",
+    }

--- a/packages/pitlane-agent/tests/scripts/__init__.py
+++ b/packages/pitlane-agent/tests/scripts/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for pitlane-agent scripts."""

--- a/packages/pitlane-agent/tests/scripts/test_lap_times.py
+++ b/packages/pitlane-agent/tests/scripts/test_lap_times.py
@@ -1,0 +1,261 @@
+"""Tests for lap_times script."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pitlane_agent.scripts.lap_times import cli, generate_lap_times_chart, setup_plot_style
+
+
+class TestLapTimesBusinessLogic:
+    """Unit tests for business logic functions."""
+
+    def test_setup_plot_style(self):
+        """Test plot style configuration."""
+        # Test that setup_plot_style doesn't raise errors
+        setup_plot_style()
+
+    @patch("pitlane_agent.scripts.lap_times.plt")
+    @patch("pitlane_agent.scripts.lap_times.fastf1")
+    def test_generate_lap_times_chart_success(
+        self, mock_fastf1, mock_plt, tmp_output_dir, mock_fastf1_session
+    ):
+        """Test successful chart generation."""
+        # Setup mocks
+        mock_fastf1.get_session.return_value = mock_fastf1_session
+
+        # Mock driver laps
+        import pandas as pd
+
+        mock_laps = pd.DataFrame(
+            [
+                {"LapNumber": 1, "LapTime": pd.Timedelta(seconds=90)},
+                {"LapNumber": 2, "LapTime": pd.Timedelta(seconds=89)},
+            ]
+        )
+        mock_fastf1_session.laps.pick_driver.return_value.pick_quicklaps.return_value = (
+            mock_laps
+        )
+
+        # Mock pyplot
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, mock_ax)
+        mock_ax.get_ylim.return_value = (85, 95)
+
+        # Mock driver color
+        mock_fastf1.plotting.get_driver_color.return_value = "#0600EF"
+
+        # Call function
+        output_path = str(tmp_output_dir / "lap_times.png")
+        result = generate_lap_times_chart(
+            year=2024,
+            gp="Monaco",
+            session_type="Q",
+            drivers=["VER", "HAM"],
+            output_path=output_path,
+        )
+
+        # Assertions
+        assert result["year"] == 2024
+        assert result["event_name"] == "Monaco Grand Prix"
+        assert "statistics" in result
+        assert result["output_path"] == output_path
+        assert len(result["drivers_plotted"]) <= 2
+
+        # Verify FastF1 was called correctly
+        mock_fastf1.get_session.assert_called_once_with(2024, "Monaco", "Q")
+        mock_fastf1_session.load.assert_called_once()
+
+    @patch("pitlane_agent.scripts.lap_times.fastf1")
+    def test_generate_lap_times_chart_error(self, mock_fastf1):
+        """Test error handling in chart generation."""
+        # Setup mock to raise error
+        mock_fastf1.get_session.side_effect = Exception("Session not found")
+
+        # Expect exception to be raised
+        with pytest.raises(Exception, match="Session not found"):
+            generate_lap_times_chart(
+                year=2024,
+                gp="InvalidGP",
+                session_type="Q",
+                drivers=["VER"],
+                output_path="/tmp/test.png",
+            )
+
+
+class TestLapTimesCLI:
+    """Integration tests for CLI interface using CliRunner."""
+
+    def test_cli_help(self):
+        """Test CLI help output."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Generate lap times chart" in result.output
+        assert "--year" in result.output
+        assert "--gp" in result.output
+        assert "--session" in result.output
+        assert "--drivers" in result.output
+
+    @patch("pitlane_agent.scripts.lap_times.generate_lap_times_chart")
+    def test_cli_success(self, mock_generate):
+        """Test successful CLI execution."""
+        # Setup mock return value
+        mock_generate.return_value = {
+            "output_path": "/tmp/test.png",
+            "event_name": "Monaco Grand Prix",
+            "session_name": "Qualifying",
+            "year": 2024,
+            "drivers_plotted": ["VER", "HAM"],
+            "statistics": [],
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--year",
+                "2024",
+                "--gp",
+                "Monaco",
+                "--session",
+                "Q",
+                "--drivers",
+                "VER",
+                "--drivers",
+                "HAM",
+                "--output",
+                "/tmp/test.png",
+            ],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify JSON output
+        output = json.loads(result.output)
+        assert output["year"] == 2024
+        assert output["event_name"] == "Monaco Grand Prix"
+
+        # Verify function was called with correct args
+        mock_generate.assert_called_once_with(
+            year=2024,
+            gp="Monaco",
+            session_type="Q",
+            drivers=["VER", "HAM"],
+            output_path="/tmp/test.png",
+        )
+
+    @patch("pitlane_agent.scripts.lap_times.generate_lap_times_chart")
+    def test_cli_single_driver(self, mock_generate):
+        """Test CLI with single driver."""
+        mock_generate.return_value = {"output_path": "/tmp/test.png"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--year",
+                "2024",
+                "--gp",
+                "Monaco",
+                "--session",
+                "Q",
+                "--drivers",
+                "VER",
+            ],
+        )
+
+        # Verify single driver was passed correctly
+        call_args = mock_generate.call_args[1]
+        assert call_args["drivers"] == ["VER"]
+
+    @patch("pitlane_agent.scripts.lap_times.generate_lap_times_chart")
+    def test_cli_multiple_drivers(self, mock_generate):
+        """Test CLI with multiple drivers using repeated options."""
+        mock_generate.return_value = {"output_path": "/tmp/test.png"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--year",
+                "2024",
+                "--gp",
+                "Monaco",
+                "--session",
+                "Q",
+                "--drivers",
+                "VER",
+                "--drivers",
+                "HAM",
+                "--drivers",
+                "LEC",
+            ],
+        )
+
+        # Verify multiple drivers were passed correctly
+        call_args = mock_generate.call_args[1]
+        assert call_args["drivers"] == ["VER", "HAM", "LEC"]
+
+    @patch("pitlane_agent.scripts.lap_times.generate_lap_times_chart")
+    def test_cli_default_output_path(self, mock_generate):
+        """Test CLI uses default output path."""
+        mock_generate.return_value = {"output_path": "/tmp/charts/lap_times.png"}
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--year",
+                "2024",
+                "--gp",
+                "Monaco",
+                "--session",
+                "Q",
+                "--drivers",
+                "VER",
+            ],
+        )
+
+        # Verify default path was used
+        call_args = mock_generate.call_args[1]
+        assert call_args["output_path"] == "/tmp/charts/lap_times.png"
+
+    @patch("pitlane_agent.scripts.lap_times.generate_lap_times_chart")
+    def test_cli_error_handling(self, mock_generate):
+        """Test CLI error handling."""
+        # Setup mock to raise error
+        mock_generate.side_effect = Exception("FastF1 error")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            [
+                "--year",
+                "2024",
+                "--gp",
+                "Monaco",
+                "--session",
+                "Q",
+                "--drivers",
+                "VER",
+            ],
+        )
+
+        assert result.exit_code == 1
+
+        # Verify error output
+        error = json.loads(result.output)
+        assert "error" in error
+        assert "FastF1 error" in error["error"]
+
+    def test_cli_missing_required_args(self):
+        """Test CLI with missing required arguments."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--year", "2024"])
+
+        assert result.exit_code != 0

--- a/packages/pitlane-agent/tests/scripts/test_session_info.py
+++ b/packages/pitlane-agent/tests/scripts/test_session_info.py
@@ -1,0 +1,135 @@
+"""Tests for session_info script."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pitlane_agent.scripts.session_info import cli, get_session_info
+
+
+class TestSessionInfoBusinessLogic:
+    """Unit tests for business logic functions."""
+
+    @patch("pitlane_agent.scripts.session_info.fastf1")
+    def test_get_session_info_success(self, mock_fastf1, mock_fastf1_session):
+        """Test successful session info retrieval."""
+        # Setup mocks
+        mock_fastf1.get_session.return_value = mock_fastf1_session
+        mock_fastf1_session.results = MagicMock()
+
+        # Create mock driver data
+        import pandas as pd
+
+        driver_data = pd.DataFrame(
+            [
+                {
+                    "Abbreviation": "VER",
+                    "FirstName": "Max",
+                    "LastName": "Verstappen",
+                    "TeamName": "Red Bull Racing",
+                    "DriverNumber": 1,
+                    "Position": 1,
+                }
+            ]
+        )
+        mock_fastf1_session.results.iterrows.return_value = driver_data.iterrows()
+
+        # Call function
+        result = get_session_info(2024, "Monaco", "Q")
+
+        # Assertions
+        assert result["year"] == 2024
+        assert result["event_name"] == "Monaco Grand Prix"
+        assert result["country"] == "Monaco"
+        assert result["session_type"] == "Q"
+        assert result["session_name"] == "Qualifying"
+        assert len(result["drivers"]) == 1
+        assert result["drivers"][0]["abbreviation"] == "VER"
+        assert result["drivers"][0]["name"] == "Max Verstappen"
+
+        # Verify FastF1 was called correctly
+        mock_fastf1.get_session.assert_called_once_with(2024, "Monaco", "Q")
+        mock_fastf1_session.load.assert_called_once()
+
+    @patch("pitlane_agent.scripts.session_info.fastf1")
+    def test_get_session_info_error(self, mock_fastf1):
+        """Test error handling in session info retrieval."""
+        # Setup mock to raise error
+        mock_fastf1.get_session.side_effect = Exception("Session not found")
+
+        # Expect exception to be raised
+        with pytest.raises(Exception, match="Session not found"):
+            get_session_info(2024, "InvalidGP", "Q")
+
+
+class TestSessionInfoCLI:
+    """Integration tests for CLI interface using CliRunner."""
+
+    def test_cli_help(self):
+        """Test CLI help output."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Get F1 session information" in result.output
+        assert "--year" in result.output
+        assert "--gp" in result.output
+        assert "--session" in result.output
+
+    @patch("pitlane_agent.scripts.session_info.get_session_info")
+    def test_cli_success(self, mock_get_session_info):
+        """Test successful CLI execution."""
+        # Setup mock return value
+        mock_get_session_info.return_value = {
+            "year": 2024,
+            "event_name": "Monaco Grand Prix",
+            "country": "Monaco",
+            "session_type": "R",
+            "session_name": "Race",
+            "date": "2024-05-26",
+            "total_laps": 78,
+            "drivers": [],
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--year", "2024", "--gp", "Monaco", "--session", "R"]
+        )
+
+        assert result.exit_code == 0
+
+        # Verify JSON output
+        output = json.loads(result.output)
+        assert output["year"] == 2024
+        assert output["event_name"] == "Monaco Grand Prix"
+
+        # Verify function was called with correct args
+        mock_get_session_info.assert_called_once_with(2024, "Monaco", "R")
+
+    @patch("pitlane_agent.scripts.session_info.get_session_info")
+    def test_cli_error_handling(self, mock_get_session_info):
+        """Test CLI error handling."""
+        # Setup mock to raise error
+        mock_get_session_info.side_effect = Exception("FastF1 error")
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli, ["--year", "2024", "--gp", "Monaco", "--session", "R"]
+        )
+
+        assert result.exit_code == 1
+
+        # Verify error output
+        error = json.loads(result.output)
+        assert "error" in error
+        assert "FastF1 error" in error["error"]
+
+    def test_cli_missing_required_args(self):
+        """Test CLI with missing required arguments."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--year", "2024"])
+
+        assert result.exit_code != 0
+        assert "Missing option" in result.output or "Error" in result.output

--- a/packages/pitlane-agent/tests/scripts/test_tyre_strategy.py
+++ b/packages/pitlane-agent/tests/scripts/test_tyre_strategy.py
@@ -1,0 +1,165 @@
+"""Tests for tyre_strategy script."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+from click.testing import CliRunner
+
+from pitlane_agent.scripts.tyre_strategy import (
+    cli,
+    generate_tyre_strategy_chart,
+    setup_plot_style,
+)
+
+
+class TestTyreStrategyBusinessLogic:
+    """Unit tests for business logic functions."""
+
+    def test_setup_plot_style(self):
+        """Test plot style configuration."""
+        # Test that setup_plot_style doesn't raise errors
+        setup_plot_style()
+
+    @patch("pitlane_agent.scripts.tyre_strategy.plt")
+    @patch("pitlane_agent.scripts.tyre_strategy.fastf1")
+    def test_generate_tyre_strategy_chart_success(
+        self, mock_fastf1, mock_plt, tmp_output_dir, mock_fastf1_session
+    ):
+        """Test successful chart generation."""
+        # Setup mocks
+        mock_fastf1.get_session.return_value = mock_fastf1_session
+
+        # Mock drivers and results
+        import pandas as pd
+
+        mock_results = pd.DataFrame(
+            [{"Abbreviation": "VER", "Position": 1}, {"Abbreviation": "HAM", "Position": 2}]
+        )
+        mock_fastf1_session.results.sort_values.return_value = mock_results
+
+        # Mock laps data
+        mock_laps = pd.DataFrame(
+            [
+                {"LapNumber": 1, "Compound": "SOFT"},
+                {"LapNumber": 2, "Compound": "SOFT"},
+                {"LapNumber": 3, "Compound": "MEDIUM"},
+            ]
+        )
+        mock_fastf1_session.laps.pick_driver.return_value = mock_laps
+
+        # Mock pyplot
+        mock_fig = MagicMock()
+        mock_ax = MagicMock()
+        mock_plt.subplots.return_value = (mock_fig, mock_ax)
+
+        # Call function
+        output_path = str(tmp_output_dir / "tyre_strategy.png")
+        result = generate_tyre_strategy_chart(
+            year=2024, gp="Monaco", session_type="R", output_path=output_path
+        )
+
+        # Assertions
+        assert result["year"] == 2024
+        assert result["event_name"] == "Monaco Grand Prix"
+        assert result["session_name"] == "Qualifying"
+        assert "strategies" in result
+        assert result["output_path"] == output_path
+
+        # Verify FastF1 was called correctly
+        mock_fastf1.get_session.assert_called_once_with(2024, "Monaco", "R")
+        mock_fastf1_session.load.assert_called_once()
+
+    @patch("pitlane_agent.scripts.tyre_strategy.fastf1")
+    def test_generate_tyre_strategy_chart_error(self, mock_fastf1):
+        """Test error handling in chart generation."""
+        # Setup mock to raise error
+        mock_fastf1.get_session.side_effect = Exception("Session not found")
+
+        # Expect exception to be raised
+        with pytest.raises(Exception, match="Session not found"):
+            generate_tyre_strategy_chart(
+                year=2024, gp="InvalidGP", session_type="R", output_path="/tmp/test.png"
+            )
+
+
+class TestTyreStrategyCLI:
+    """Integration tests for CLI interface using CliRunner."""
+
+    def test_cli_help(self):
+        """Test CLI help output."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--help"])
+
+        assert result.exit_code == 0
+        assert "Generate tyre strategy" in result.output
+        assert "--year" in result.output
+        assert "--gp" in result.output
+        assert "--session" in result.output
+        assert "--output" in result.output
+
+    @patch("pitlane_agent.scripts.tyre_strategy.generate_tyre_strategy_chart")
+    def test_cli_success(self, mock_generate):
+        """Test successful CLI execution."""
+        # Setup mock return value
+        mock_generate.return_value = {
+            "output_path": "/tmp/test.png",
+            "event_name": "Monaco Grand Prix",
+            "session_name": "Race",
+            "year": 2024,
+            "total_laps": 78,
+            "strategies": [],
+        }
+
+        runner = CliRunner()
+        result = runner.invoke(
+            cli,
+            ["--year", "2024", "--gp", "Monaco", "--session", "R", "--output", "/tmp/test.png"],
+        )
+
+        assert result.exit_code == 0
+
+        # Verify JSON output
+        output = json.loads(result.output)
+        assert output["year"] == 2024
+        assert output["event_name"] == "Monaco Grand Prix"
+
+        # Verify function was called with correct args
+        mock_generate.assert_called_once_with(
+            year=2024, gp="Monaco", session_type="R", output_path="/tmp/test.png"
+        )
+
+    @patch("pitlane_agent.scripts.tyre_strategy.generate_tyre_strategy_chart")
+    def test_cli_default_session(self, mock_generate):
+        """Test CLI uses default session type R."""
+        mock_generate.return_value = {"output_path": "/tmp/test.png"}
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--year", "2024", "--gp", "Monaco"])
+
+        # Verify default session was used
+        call_args = mock_generate.call_args[1]
+        assert call_args["session_type"] == "R"
+
+    @patch("pitlane_agent.scripts.tyre_strategy.generate_tyre_strategy_chart")
+    def test_cli_error_handling(self, mock_generate):
+        """Test CLI error handling."""
+        # Setup mock to raise error
+        mock_generate.side_effect = Exception("Chart generation failed")
+
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--year", "2024", "--gp", "Monaco"])
+
+        assert result.exit_code == 1
+
+        # Verify error output
+        error = json.loads(result.output)
+        assert "error" in error
+        assert "Chart generation failed" in error["error"]
+
+    def test_cli_missing_required_args(self):
+        """Test CLI with missing required arguments."""
+        runner = CliRunner()
+        result = runner.invoke(cli, ["--year", "2024"])
+
+        assert result.exit_code != 0

--- a/packages/pitlane-agent/tests/test_agent.py
+++ b/packages/pitlane-agent/tests/test_agent.py
@@ -1,0 +1,312 @@
+"""Tests for the F1Agent class."""
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from pitlane_agent.agent import CHARTS_DIR, F1Agent, PACKAGE_DIR
+
+
+class TestF1AgentInitialization:
+    """Tests for F1Agent initialization."""
+
+    def test_init_default_charts_dir(self, tmp_path):
+        """Test initialization with default charts directory."""
+        with patch("pitlane_agent.agent.CHARTS_DIR", tmp_path / "default_charts"):
+            agent = F1Agent()
+
+            assert agent.charts_dir == tmp_path / "default_charts"
+            assert agent.charts_dir.exists()
+
+    def test_init_custom_charts_dir(self, tmp_path):
+        """Test initialization with custom charts directory."""
+        custom_dir = tmp_path / "custom_charts"
+        agent = F1Agent(charts_dir=custom_dir)
+
+        assert agent.charts_dir == custom_dir
+        assert agent.charts_dir.exists()
+
+    def test_init_creates_charts_dir_if_missing(self, tmp_path):
+        """Test that charts directory is created if it doesn't exist."""
+        charts_dir = tmp_path / "new" / "nested" / "charts"
+        assert not charts_dir.exists()
+
+        agent = F1Agent(charts_dir=charts_dir)
+
+        assert agent.charts_dir == charts_dir
+        assert charts_dir.exists()
+
+    def test_init_uses_default_charts_dir_constant(self):
+        """Test that default uses CHARTS_DIR constant."""
+        agent = F1Agent()
+        assert agent.charts_dir == CHARTS_DIR
+
+
+class TestF1AgentChat:
+    """Tests for F1Agent.chat method."""
+
+    @pytest.mark.asyncio
+    async def test_chat_yields_text_chunks(self):
+        """Test that chat yields text chunks from assistant messages."""
+        # Create mock TextBlock objects
+        from claude_agent_sdk.types import TextBlock
+
+        text_block_1 = TextBlock(text="Hello ")
+        text_block_2 = TextBlock(text="from F1 Agent!")
+
+        # Create mock AssistantMessage with text blocks
+        from claude_agent_sdk.types import AssistantMessage
+
+        mock_msg_1 = MagicMock(spec=AssistantMessage)
+        mock_msg_1.content = [text_block_1]
+
+        mock_msg_2 = MagicMock(spec=AssistantMessage)
+        mock_msg_2.content = [text_block_2]
+
+        # Create mock client
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock()
+
+        # Mock receive_response to yield assistant messages
+        async def mock_receive():
+            yield mock_msg_1
+            yield mock_msg_2
+
+        mock_client.receive_response = mock_receive
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        # Patch ClaudeSDKClient
+        with patch("pitlane_agent.agent.ClaudeSDKClient", return_value=mock_client):
+            agent = F1Agent()
+            chunks = []
+
+            async for chunk in agent.chat("What is F1?"):
+                chunks.append(chunk)
+
+            assert chunks == ["Hello ", "from F1 Agent!"]
+            mock_client.query.assert_called_once_with("What is F1?")
+
+    @pytest.mark.asyncio
+    async def test_chat_passes_correct_options(self):
+        """Test that chat passes correct options to ClaudeSDKClient."""
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock()
+
+        # Mock receive_response as an async generator
+        async def mock_receive():
+            return
+            yield  # Make it an async generator
+
+        mock_client.receive_response = mock_receive
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("pitlane_agent.agent.ClaudeSDKClient") as MockClient:
+            MockClient.return_value = mock_client
+
+            agent = F1Agent()
+            async for _ in agent.chat("Test"):
+                pass
+
+            # Verify ClaudeSDKClient was called with correct options
+            call_args = MockClient.call_args
+            options = call_args.kwargs["options"]
+
+            assert options.cwd == str(PACKAGE_DIR)
+            assert options.setting_sources == ["project"]
+            assert options.allowed_tools == ["Skill", "Bash", "Read", "Write"]
+
+    @pytest.mark.asyncio
+    async def test_chat_handles_multiple_text_blocks(self):
+        """Test that chat handles messages with multiple text blocks."""
+        from claude_agent_sdk.types import AssistantMessage, TextBlock
+
+        # Create message with multiple text blocks
+        text_blocks = [
+            TextBlock(text="First block "),
+            TextBlock(text="Second block "),
+            TextBlock(text="Third block"),
+        ]
+
+        mock_msg = MagicMock(spec=AssistantMessage)
+        mock_msg.content = text_blocks
+
+        # Create mock client
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock()
+
+        async def mock_receive():
+            yield mock_msg
+
+        mock_client.receive_response = mock_receive
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("pitlane_agent.agent.ClaudeSDKClient", return_value=mock_client):
+            agent = F1Agent()
+            chunks = []
+
+            async for chunk in agent.chat("Test"):
+                chunks.append(chunk)
+
+            assert chunks == ["First block ", "Second block ", "Third block"]
+
+    @pytest.mark.asyncio
+    async def test_chat_filters_non_text_blocks(self):
+        """Test that chat only yields TextBlock content."""
+        from claude_agent_sdk.types import AssistantMessage, TextBlock
+
+        # Create message with mixed content types
+        text_block = TextBlock(text="Text content")
+        non_text_block = MagicMock()  # Some other block type
+
+        mock_msg = MagicMock(spec=AssistantMessage)
+        mock_msg.content = [text_block, non_text_block]
+
+        # Create mock client
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock()
+
+        async def mock_receive():
+            yield mock_msg
+
+        mock_client.receive_response = mock_receive
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("pitlane_agent.agent.ClaudeSDKClient", return_value=mock_client):
+            agent = F1Agent()
+            chunks = []
+
+            async for chunk in agent.chat("Test"):
+                chunks.append(chunk)
+
+            # Should only yield the TextBlock content
+            assert chunks == ["Text content"]
+
+    @pytest.mark.asyncio
+    async def test_chat_filters_non_assistant_messages(self):
+        """Test that chat only processes AssistantMessage types."""
+        from claude_agent_sdk.types import AssistantMessage, TextBlock
+
+        # Create an assistant message and a non-assistant message
+        text_block = TextBlock(text="Assistant response")
+        assistant_msg = MagicMock(spec=AssistantMessage)
+        assistant_msg.content = [text_block]
+
+        other_msg = MagicMock()  # Not an AssistantMessage
+
+        # Create mock client
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock()
+
+        async def mock_receive():
+            yield other_msg
+            yield assistant_msg
+
+        mock_client.receive_response = mock_receive
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("pitlane_agent.agent.ClaudeSDKClient", return_value=mock_client):
+            agent = F1Agent()
+            chunks = []
+
+            async for chunk in agent.chat("Test"):
+                chunks.append(chunk)
+
+            # Should only yield content from AssistantMessage
+            assert chunks == ["Assistant response"]
+
+
+class TestF1AgentChatFull:
+    """Tests for F1Agent.chat_full method."""
+
+    @pytest.mark.asyncio
+    async def test_chat_full_returns_complete_response(self):
+        """Test that chat_full returns the complete response."""
+        from claude_agent_sdk.types import AssistantMessage, TextBlock
+
+        # Create mock messages
+        text_block_1 = TextBlock(text="First chunk")
+        text_block_2 = TextBlock(text="Second chunk")
+        text_block_3 = TextBlock(text="Third chunk")
+
+        mock_msg_1 = MagicMock(spec=AssistantMessage)
+        mock_msg_1.content = [text_block_1]
+
+        mock_msg_2 = MagicMock(spec=AssistantMessage)
+        mock_msg_2.content = [text_block_2, text_block_3]
+
+        # Create mock client
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock()
+
+        async def mock_receive():
+            yield mock_msg_1
+            yield mock_msg_2
+
+        mock_client.receive_response = mock_receive
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("pitlane_agent.agent.ClaudeSDKClient", return_value=mock_client):
+            agent = F1Agent()
+            response = await agent.chat_full("What is F1?")
+
+            # Should join all chunks with newlines
+            assert response == "First chunk\nSecond chunk\nThird chunk"
+            mock_client.query.assert_called_once_with("What is F1?")
+
+    @pytest.mark.asyncio
+    async def test_chat_full_returns_empty_string_for_no_response(self):
+        """Test that chat_full returns empty string when there's no response."""
+        # Create mock client with no messages
+        mock_client = AsyncMock()
+        mock_client.query = AsyncMock()
+
+        async def mock_receive():
+            return
+            yield  # Make it an async generator
+
+        mock_client.receive_response = mock_receive
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=None)
+
+        with patch("pitlane_agent.agent.ClaudeSDKClient", return_value=mock_client):
+            agent = F1Agent()
+            response = await agent.chat_full("Test")
+
+            assert response == ""
+
+    @pytest.mark.asyncio
+    async def test_chat_full_uses_chat_method(self):
+        """Test that chat_full internally uses the chat method."""
+        agent = F1Agent()
+
+        # Mock the chat method
+        async def mock_chat(message):
+            yield "Chunk 1"
+            yield "Chunk 2"
+
+        with patch.object(agent, "chat", side_effect=mock_chat):
+            response = await agent.chat_full("Test message")
+
+            assert response == "Chunk 1\nChunk 2"
+
+
+class TestF1AgentConstants:
+    """Tests for module-level constants."""
+
+    def test_package_dir_is_correct(self):
+        """Test that PACKAGE_DIR points to the package directory."""
+        # PACKAGE_DIR should point to the pitlane_agent package directory
+        assert PACKAGE_DIR.name == "pitlane_agent"
+        assert PACKAGE_DIR.is_dir()
+        assert (PACKAGE_DIR / "__init__.py").exists()
+
+    def test_charts_dir_constant(self):
+        """Test that CHARTS_DIR has expected value."""
+        assert CHARTS_DIR == Path("/tmp/pitlane_charts")

--- a/packages/pitlane-agent/tests/test_cli.py
+++ b/packages/pitlane-agent/tests/test_cli.py
@@ -1,0 +1,60 @@
+"""Tests for the main pitlane CLI group."""
+
+from click.testing import CliRunner
+
+from pitlane_agent.cli import pitlane
+
+
+class TestCLIGroup:
+    """Tests for the main CLI group."""
+
+    def test_main_help(self):
+        """Test main CLI help output shows all subcommands."""
+        runner = CliRunner()
+        result = runner.invoke(pitlane, ["--help"])
+
+        assert result.exit_code == 0
+        assert "PitLane AI" in result.output
+        assert "lap-times" in result.output
+        assert "session-info" in result.output
+        assert "tyre-strategy" in result.output
+
+    def test_subcommand_lap_times_help(self):
+        """Test lap-times subcommand help."""
+        runner = CliRunner()
+        result = runner.invoke(pitlane, ["lap-times", "--help"])
+
+        assert result.exit_code == 0
+        assert "Generate lap times chart" in result.output
+        assert "--year" in result.output
+        assert "--gp" in result.output
+        assert "--drivers" in result.output
+
+    def test_subcommand_session_info_help(self):
+        """Test session-info subcommand help."""
+        runner = CliRunner()
+        result = runner.invoke(pitlane, ["session-info", "--help"])
+
+        assert result.exit_code == 0
+        assert "Get F1 session information" in result.output
+        assert "--year" in result.output
+        assert "--gp" in result.output
+        assert "--session" in result.output
+
+    def test_subcommand_tyre_strategy_help(self):
+        """Test tyre-strategy subcommand help."""
+        runner = CliRunner()
+        result = runner.invoke(pitlane, ["tyre-strategy", "--help"])
+
+        assert result.exit_code == 0
+        assert "Generate tyre strategy" in result.output
+        assert "--year" in result.output
+        assert "--gp" in result.output
+
+    def test_invalid_subcommand(self):
+        """Test invalid subcommand returns error."""
+        runner = CliRunner()
+        result = runner.invoke(pitlane, ["invalid-command"])
+
+        assert result.exit_code != 0
+        assert "Error" in result.output or "No such command" in result.output

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ requires-python = ">=3.11"
 
 [dependency-groups]
 dev = [
+    "pytest-asyncio>=0.24",
+    "pytest-cov>=4.1",
+    "pytest-mock>=3.12",
+    "pytest>=8.0",
     "ruff>=0.8.4",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -338,6 +338,98 @@ wheels = [
 ]
 
 [[package]]
+name = "coverage"
+version = "7.13.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/23/f9/e92df5e07f3fc8d4c7f9a0f146ef75446bf870351cd37b788cf5897f8079/coverage-7.13.1.tar.gz", hash = "sha256:b7593fe7eb5feaa3fbb461ac79aac9f9fc0387a5ca8080b0c6fe2ca27b091afd", size = 825862, upload-time = "2025-12-28T15:42:56.969Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b4/9b/77baf488516e9ced25fc215a6f75d803493fc3f6a1a1227ac35697910c2a/coverage-7.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1a55d509a1dc5a5b708b5dad3b5334e07a16ad4c2185e27b40e4dba796ab7f88", size = 218755, upload-time = "2025-12-28T15:40:30.812Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/cd/7ab01154e6eb79ee2fab76bf4d89e94c6648116557307ee4ebbb85e5c1bf/coverage-7.13.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:4d010d080c4888371033baab27e47c9df7d6fb28d0b7b7adf85a4a49be9298b3", size = 219257, upload-time = "2025-12-28T15:40:32.333Z" },
+    { url = "https://files.pythonhosted.org/packages/01/d5/b11ef7863ffbbdb509da0023fad1e9eda1c0eaea61a6d2ea5b17d4ac706e/coverage-7.13.1-cp311-cp311-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d938b4a840fb1523b9dfbbb454f652967f18e197569c32266d4d13f37244c3d9", size = 249657, upload-time = "2025-12-28T15:40:34.1Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/7c/347280982982383621d29b8c544cf497ae07ac41e44b1ca4903024131f55/coverage-7.13.1-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bf100a3288f9bb7f919b87eb84f87101e197535b9bd0e2c2b5b3179633324fee", size = 251581, upload-time = "2025-12-28T15:40:36.131Z" },
+    { url = "https://files.pythonhosted.org/packages/82/f6/ebcfed11036ade4c0d75fa4453a6282bdd225bc073862766eec184a4c643/coverage-7.13.1-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ef6688db9bf91ba111ae734ba6ef1a063304a881749726e0d3575f5c10a9facf", size = 253691, upload-time = "2025-12-28T15:40:37.626Z" },
+    { url = "https://files.pythonhosted.org/packages/02/92/af8f5582787f5d1a8b130b2dcba785fa5e9a7a8e121a0bb2220a6fdbdb8a/coverage-7.13.1-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0b609fc9cdbd1f02e51f67f51e5aee60a841ef58a68d00d5ee2c0faf357481a3", size = 249799, upload-time = "2025-12-28T15:40:39.47Z" },
+    { url = "https://files.pythonhosted.org/packages/24/aa/0e39a2a3b16eebf7f193863323edbff38b6daba711abaaf807d4290cf61a/coverage-7.13.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:c43257717611ff5e9a1d79dce8e47566235ebda63328718d9b65dd640bc832ef", size = 251389, upload-time = "2025-12-28T15:40:40.954Z" },
+    { url = "https://files.pythonhosted.org/packages/73/46/7f0c13111154dc5b978900c0ccee2e2ca239b910890e674a77f1363d483e/coverage-7.13.1-cp311-cp311-musllinux_1_2_i686.whl", hash = "sha256:e09fbecc007f7b6afdfb3b07ce5bd9f8494b6856dd4f577d26c66c391b829851", size = 249450, upload-time = "2025-12-28T15:40:42.489Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ca/e80da6769e8b669ec3695598c58eef7ad98b0e26e66333996aee6316db23/coverage-7.13.1-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:a03a4f3a19a189919c7055098790285cc5c5b0b3976f8d227aea39dbf9f8bfdb", size = 249170, upload-time = "2025-12-28T15:40:44.279Z" },
+    { url = "https://files.pythonhosted.org/packages/af/18/9e29baabdec1a8644157f572541079b4658199cfd372a578f84228e860de/coverage-7.13.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:3820778ea1387c2b6a818caec01c63adc5b3750211af6447e8dcfb9b6f08dbba", size = 250081, upload-time = "2025-12-28T15:40:45.748Z" },
+    { url = "https://files.pythonhosted.org/packages/00/f8/c3021625a71c3b2f516464d322e41636aea381018319050a8114105872ee/coverage-7.13.1-cp311-cp311-win32.whl", hash = "sha256:ff10896fa55167371960c5908150b434b71c876dfab97b69478f22c8b445ea19", size = 221281, upload-time = "2025-12-28T15:40:47.232Z" },
+    { url = "https://files.pythonhosted.org/packages/27/56/c216625f453df6e0559ed666d246fcbaaa93f3aa99eaa5080cea1229aa3d/coverage-7.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:a998cc0aeeea4c6d5622a3754da5a493055d2d95186bad877b0a34ea6e6dbe0a", size = 222215, upload-time = "2025-12-28T15:40:49.19Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/9a/be342e76f6e531cae6406dc46af0d350586f24d9b67fdfa6daee02df71af/coverage-7.13.1-cp311-cp311-win_arm64.whl", hash = "sha256:fea07c1a39a22614acb762e3fbbb4011f65eedafcb2948feeef641ac78b4ee5c", size = 220886, upload-time = "2025-12-28T15:40:51.067Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8a/87af46cccdfa78f53db747b09f5f9a21d5fc38d796834adac09b30a8ce74/coverage-7.13.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6f34591000f06e62085b1865c9bc5f7858df748834662a51edadfd2c3bfe0dd3", size = 218927, upload-time = "2025-12-28T15:40:52.814Z" },
+    { url = "https://files.pythonhosted.org/packages/82/a8/6e22fdc67242a4a5a153f9438d05944553121c8f4ba70cb072af4c41362e/coverage-7.13.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b67e47c5595b9224599016e333f5ec25392597a89d5744658f837d204e16c63e", size = 219288, upload-time = "2025-12-28T15:40:54.262Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/0a/853a76e03b0f7c4375e2ca025df45c918beb367f3e20a0a8e91967f6e96c/coverage-7.13.1-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3e7b8bd70c48ffb28461ebe092c2345536fb18bbbf19d287c8913699735f505c", size = 250786, upload-time = "2025-12-28T15:40:56.059Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/b4/694159c15c52b9f7ec7adf49d50e5f8ee71d3e9ef38adb4445d13dd56c20/coverage-7.13.1-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c223d078112e90dc0e5c4e35b98b9584164bea9fbbd221c0b21c5241f6d51b62", size = 253543, upload-time = "2025-12-28T15:40:57.585Z" },
+    { url = "https://files.pythonhosted.org/packages/96/b2/7f1f0437a5c855f87e17cf5d0dc35920b6440ff2b58b1ba9788c059c26c8/coverage-7.13.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:794f7c05af0763b1bbd1b9e6eff0e52ad068be3b12cd96c87de037b01390c968", size = 254635, upload-time = "2025-12-28T15:40:59.443Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/d1/73c3fdb8d7d3bddd9473c9c6a2e0682f09fc3dfbcb9c3f36412a7368bcab/coverage-7.13.1-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:0642eae483cc8c2902e4af7298bf886d605e80f26382124cddc3967c2a3df09e", size = 251202, upload-time = "2025-12-28T15:41:01.328Z" },
+    { url = "https://files.pythonhosted.org/packages/66/3c/f0edf75dcc152f145d5598329e864bbbe04ab78660fe3e8e395f9fff010f/coverage-7.13.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9f5e772ed5fef25b3de9f2008fe67b92d46831bd2bc5bdc5dd6bfd06b83b316f", size = 252566, upload-time = "2025-12-28T15:41:03.319Z" },
+    { url = "https://files.pythonhosted.org/packages/17/b3/e64206d3c5f7dcbceafd14941345a754d3dbc78a823a6ed526e23b9cdaab/coverage-7.13.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:45980ea19277dc0a579e432aef6a504fe098ef3a9032ead15e446eb0f1191aee", size = 250711, upload-time = "2025-12-28T15:41:06.411Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/ad/28a3eb970a8ef5b479ee7f0c484a19c34e277479a5b70269dc652b730733/coverage-7.13.1-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:e4f18eca6028ffa62adbd185a8f1e1dd242f2e68164dba5c2b74a5204850b4cf", size = 250278, upload-time = "2025-12-28T15:41:08.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/e3/c8f0f1a93133e3e1291ca76cbb63565bd4b5c5df63b141f539d747fff348/coverage-7.13.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8dca5590fec7a89ed6826fce625595279e586ead52e9e958d3237821fbc750c", size = 252154, upload-time = "2025-12-28T15:41:09.969Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bf/9939c5d6859c380e405b19e736321f1c7d402728792f4c752ad1adcce005/coverage-7.13.1-cp312-cp312-win32.whl", hash = "sha256:ff86d4e85188bba72cfb876df3e11fa243439882c55957184af44a35bd5880b7", size = 221487, upload-time = "2025-12-28T15:41:11.468Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/dc/7282856a407c621c2aad74021680a01b23010bb8ebf427cf5eacda2e876f/coverage-7.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:16cc1da46c04fb0fb128b4dc430b78fa2aba8a6c0c9f8eb391fd5103409a6ac6", size = 222299, upload-time = "2025-12-28T15:41:13.386Z" },
+    { url = "https://files.pythonhosted.org/packages/10/79/176a11203412c350b3e9578620013af35bcdb79b651eb976f4a4b32044fa/coverage-7.13.1-cp312-cp312-win_arm64.whl", hash = "sha256:8d9bc218650022a768f3775dd7fdac1886437325d8d295d923ebcfef4892ad5c", size = 220941, upload-time = "2025-12-28T15:41:14.975Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/a4/e98e689347a1ff1a7f67932ab535cef82eb5e78f32a9e4132e114bbb3a0a/coverage-7.13.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:cb237bfd0ef4d5eb6a19e29f9e528ac67ac3be932ea6b44fb6cc09b9f3ecff78", size = 218951, upload-time = "2025-12-28T15:41:16.653Z" },
+    { url = "https://files.pythonhosted.org/packages/32/33/7cbfe2bdc6e2f03d6b240d23dc45fdaf3fd270aaf2d640be77b7f16989ab/coverage-7.13.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1dcb645d7e34dcbcc96cd7c132b1fc55c39263ca62eb961c064eb3928997363b", size = 219325, upload-time = "2025-12-28T15:41:18.609Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f6/efdabdb4929487baeb7cb2a9f7dac457d9356f6ad1b255be283d58b16316/coverage-7.13.1-cp313-cp313-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3d42df8201e00384736f0df9be2ced39324c3907607d17d50d50116c989d84cd", size = 250309, upload-time = "2025-12-28T15:41:20.629Z" },
+    { url = "https://files.pythonhosted.org/packages/12/da/91a52516e9d5aea87d32d1523f9cdcf7a35a3b298e6be05d6509ba3cfab2/coverage-7.13.1-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fa3edde1aa8807de1d05934982416cb3ec46d1d4d91e280bcce7cca01c507992", size = 252907, upload-time = "2025-12-28T15:41:22.257Z" },
+    { url = "https://files.pythonhosted.org/packages/75/38/f1ea837e3dc1231e086db1638947e00d264e7e8c41aa8ecacf6e1e0c05f4/coverage-7.13.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9edd0e01a343766add6817bc448408858ba6b489039eaaa2018474e4001651a4", size = 254148, upload-time = "2025-12-28T15:41:23.87Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/43/f4f16b881aaa34954ba446318dea6b9ed5405dd725dd8daac2358eda869a/coverage-7.13.1-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:985b7836931d033570b94c94713c6dba5f9d3ff26045f72c3e5dbc5fe3361e5a", size = 250515, upload-time = "2025-12-28T15:41:25.437Z" },
+    { url = "https://files.pythonhosted.org/packages/84/34/8cba7f00078bd468ea914134e0144263194ce849ec3baad187ffb6203d1c/coverage-7.13.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ffed1e4980889765c84a5d1a566159e363b71d6b6fbaf0bebc9d3c30bc016766", size = 252292, upload-time = "2025-12-28T15:41:28.459Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/a4/cffac66c7652d84ee4ac52d3ccb94c015687d3b513f9db04bfcac2ac800d/coverage-7.13.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:8842af7f175078456b8b17f1b73a0d16a65dcbdc653ecefeb00a56b3c8c298c4", size = 250242, upload-time = "2025-12-28T15:41:30.02Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/78/9a64d462263dde416f3c0067efade7b52b52796f489b1037a95b0dc389c9/coverage-7.13.1-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:ccd7a6fca48ca9c131d9b0a2972a581e28b13416fc313fb98b6d24a03ce9a398", size = 250068, upload-time = "2025-12-28T15:41:32.007Z" },
+    { url = "https://files.pythonhosted.org/packages/69/c8/a8994f5fece06db7c4a97c8fc1973684e178599b42e66280dded0524ef00/coverage-7.13.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0403f647055de2609be776965108447deb8e384fe4a553c119e3ff6bfbab4784", size = 251846, upload-time = "2025-12-28T15:41:33.946Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f7/91fa73c4b80305c86598a2d4e54ba22df6bf7d0d97500944af7ef155d9f7/coverage-7.13.1-cp313-cp313-win32.whl", hash = "sha256:549d195116a1ba1e1ae2f5ca143f9777800f6636eab917d4f02b5310d6d73461", size = 221512, upload-time = "2025-12-28T15:41:35.519Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0b/0768b4231d5a044da8f75e097a8714ae1041246bb765d6b5563bab456735/coverage-7.13.1-cp313-cp313-win_amd64.whl", hash = "sha256:5899d28b5276f536fcf840b18b61a9fce23cc3aec1d114c44c07fe94ebeaa500", size = 222321, upload-time = "2025-12-28T15:41:37.371Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/b8/bdcb7253b7e85157282450262008f1366aa04663f3e3e4c30436f596c3e2/coverage-7.13.1-cp313-cp313-win_arm64.whl", hash = "sha256:868a2fae76dfb06e87291bcbd4dcbcc778a8500510b618d50496e520bd94d9b9", size = 220949, upload-time = "2025-12-28T15:41:39.553Z" },
+    { url = "https://files.pythonhosted.org/packages/70/52/f2be52cc445ff75ea8397948c96c1b4ee14f7f9086ea62fc929c5ae7b717/coverage-7.13.1-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:67170979de0dacac3f3097d02b0ad188d8edcea44ccc44aaa0550af49150c7dc", size = 219643, upload-time = "2025-12-28T15:41:41.567Z" },
+    { url = "https://files.pythonhosted.org/packages/47/79/c85e378eaa239e2edec0c5523f71542c7793fe3340954eafb0bc3904d32d/coverage-7.13.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:f80e2bb21bfab56ed7405c2d79d34b5dc0bc96c2c1d2a067b643a09fb756c43a", size = 219997, upload-time = "2025-12-28T15:41:43.418Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/9b/b1ade8bfb653c0bbce2d6d6e90cc6c254cbb99b7248531cc76253cb4da6d/coverage-7.13.1-cp313-cp313t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:f83351e0f7dcdb14d7326c3d8d8c4e915fa685cbfdc6281f9470d97a04e9dfe4", size = 261296, upload-time = "2025-12-28T15:41:45.207Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/af/ebf91e3e1a2473d523e87e87fd8581e0aa08741b96265730e2d79ce78d8d/coverage-7.13.1-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:bb3f6562e89bad0110afbe64e485aac2462efdce6232cdec7862a095dc3412f6", size = 263363, upload-time = "2025-12-28T15:41:47.163Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/8b/fb2423526d446596624ac7fde12ea4262e66f86f5120114c3cfd0bb2befa/coverage-7.13.1-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:77545b5dcda13b70f872c3b5974ac64c21d05e65b1590b441c8560115dc3a0d1", size = 265783, upload-time = "2025-12-28T15:41:49.03Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/26/ef2adb1e22674913b89f0fe7490ecadcef4a71fa96f5ced90c60ec358789/coverage-7.13.1-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:a4d240d260a1aed814790bbe1f10a5ff31ce6c21bc78f0da4a1e8268d6c80dbd", size = 260508, upload-time = "2025-12-28T15:41:51.035Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/7d/f0f59b3404caf662e7b5346247883887687c074ce67ba453ea08c612b1d5/coverage-7.13.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d2287ac9360dec3837bfdad969963a5d073a09a85d898bd86bea82aa8876ef3c", size = 263357, upload-time = "2025-12-28T15:41:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/b1/29896492b0b1a047604d35d6fa804f12818fa30cdad660763a5f3159e158/coverage-7.13.1-cp313-cp313t-musllinux_1_2_i686.whl", hash = "sha256:0d2c11f3ea4db66b5cbded23b20185c35066892c67d80ec4be4bab257b9ad1e0", size = 260978, upload-time = "2025-12-28T15:41:54.589Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f2/971de1238a62e6f0a4128d37adadc8bb882ee96afbe03ff1570291754629/coverage-7.13.1-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:3fc6a169517ca0d7ca6846c3c5392ef2b9e38896f61d615cb75b9e7134d4ee1e", size = 259877, upload-time = "2025-12-28T15:41:56.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/fc/0474efcbb590ff8628830e9aaec5f1831594874360e3251f1fdec31d07a3/coverage-7.13.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d10a2ed46386e850bb3de503a54f9fe8192e5917fcbb143bfef653a9355e9a53", size = 262069, upload-time = "2025-12-28T15:41:58.093Z" },
+    { url = "https://files.pythonhosted.org/packages/88/4f/3c159b7953db37a7b44c0eab8a95c37d1aa4257c47b4602c04022d5cb975/coverage-7.13.1-cp313-cp313t-win32.whl", hash = "sha256:75a6f4aa904301dab8022397a22c0039edc1f51e90b83dbd4464b8a38dc87842", size = 222184, upload-time = "2025-12-28T15:41:59.763Z" },
+    { url = "https://files.pythonhosted.org/packages/58/a5/6b57d28f81417f9335774f20679d9d13b9a8fb90cd6160957aa3b54a2379/coverage-7.13.1-cp313-cp313t-win_amd64.whl", hash = "sha256:309ef5706e95e62578cda256b97f5e097916a2c26247c287bbe74794e7150df2", size = 223250, upload-time = "2025-12-28T15:42:01.52Z" },
+    { url = "https://files.pythonhosted.org/packages/81/7c/160796f3b035acfbb58be80e02e484548595aa67e16a6345e7910ace0a38/coverage-7.13.1-cp313-cp313t-win_arm64.whl", hash = "sha256:92f980729e79b5d16d221038dbf2e8f9a9136afa072f9d5d6ed4cb984b126a09", size = 221521, upload-time = "2025-12-28T15:42:03.275Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/8e/ba0e597560c6563fc0adb902fda6526df5d4aa73bb10adf0574d03bd2206/coverage-7.13.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:97ab3647280d458a1f9adb85244e81587505a43c0c7cff851f5116cd2814b894", size = 218996, upload-time = "2025-12-28T15:42:04.978Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/8e/764c6e116f4221dc7aa26c4061181ff92edb9c799adae6433d18eeba7a14/coverage-7.13.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8f572d989142e0908e6acf57ad1b9b86989ff057c006d13b76c146ec6a20216a", size = 219326, upload-time = "2025-12-28T15:42:06.691Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/a6/6130dc6d8da28cdcbb0f2bf8865aeca9b157622f7c0031e48c6cf9a0e591/coverage-7.13.1-cp314-cp314-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:d72140ccf8a147e94274024ff6fd8fb7811354cf7ef88b1f0a988ebaa5bc774f", size = 250374, upload-time = "2025-12-28T15:42:08.786Z" },
+    { url = "https://files.pythonhosted.org/packages/82/2b/783ded568f7cd6b677762f780ad338bf4b4750205860c17c25f7c708995e/coverage-7.13.1-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:d3c9f051b028810f5a87c88e5d6e9af3c0ff32ef62763bf15d29f740453ca909", size = 252882, upload-time = "2025-12-28T15:42:10.515Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/b2/9808766d082e6a4d59eb0cc881a57fc1600eb2c5882813eefff8254f71b5/coverage-7.13.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f398ba4df52d30b1763f62eed9de5620dcde96e6f491f4c62686736b155aa6e4", size = 254218, upload-time = "2025-12-28T15:42:12.208Z" },
+    { url = "https://files.pythonhosted.org/packages/44/ea/52a985bb447c871cb4d2e376e401116520991b597c85afdde1ea9ef54f2c/coverage-7.13.1-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:132718176cc723026d201e347f800cd1a9e4b62ccd3f82476950834dad501c75", size = 250391, upload-time = "2025-12-28T15:42:14.21Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/1d/125b36cc12310718873cfc8209ecfbc1008f14f4f5fa0662aa608e579353/coverage-7.13.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:9e549d642426e3579b3f4b92d0431543b012dcb6e825c91619d4e93b7363c3f9", size = 252239, upload-time = "2025-12-28T15:42:16.292Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/16/10c1c164950cade470107f9f14bbac8485f8fb8515f515fca53d337e4a7f/coverage-7.13.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:90480b2134999301eea795b3a9dbf606c6fbab1b489150c501da84a959442465", size = 250196, upload-time = "2025-12-28T15:42:18.54Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c6/cd860fac08780c6fd659732f6ced1b40b79c35977c1356344e44d72ba6c4/coverage-7.13.1-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e825dbb7f84dfa24663dd75835e7257f8882629fc11f03ecf77d84a75134b864", size = 250008, upload-time = "2025-12-28T15:42:20.365Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/a8c58d3d38f82a5711e1e0a67268362af48e1a03df27c03072ac30feefcf/coverage-7.13.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:623dcc6d7a7ba450bbdbeedbaa0c42b329bdae16491af2282f12a7e809be7eb9", size = 251671, upload-time = "2025-12-28T15:42:22.114Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/bc/fd4c1da651d037a1e3d53e8cb3f8182f4b53271ffa9a95a2e211bacc0349/coverage-7.13.1-cp314-cp314-win32.whl", hash = "sha256:6e73ebb44dca5f708dc871fe0b90cf4cff1a13f9956f747cc87b535a840386f5", size = 221777, upload-time = "2025-12-28T15:42:23.919Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/50/71acabdc8948464c17e90b5ffd92358579bd0910732c2a1c9537d7536aa6/coverage-7.13.1-cp314-cp314-win_amd64.whl", hash = "sha256:be753b225d159feb397bd0bf91ae86f689bad0da09d3b301478cd39b878ab31a", size = 222592, upload-time = "2025-12-28T15:42:25.619Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/c8/a6fb943081bb0cc926499c7907731a6dc9efc2cbdc76d738c0ab752f1a32/coverage-7.13.1-cp314-cp314-win_arm64.whl", hash = "sha256:228b90f613b25ba0019361e4ab81520b343b622fc657daf7e501c4ed6a2366c0", size = 221169, upload-time = "2025-12-28T15:42:27.629Z" },
+    { url = "https://files.pythonhosted.org/packages/16/61/d5b7a0a0e0e40d62e59bc8c7aa1afbd86280d82728ba97f0673b746b78e2/coverage-7.13.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:60cfb538fe9ef86e5b2ab0ca8fc8d62524777f6c611dcaf76dc16fbe9b8e698a", size = 219730, upload-time = "2025-12-28T15:42:29.306Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/2c/8881326445fd071bb49514d1ce97d18a46a980712b51fee84f9ab42845b4/coverage-7.13.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:57dfc8048c72ba48a8c45e188d811e5efd7e49b387effc8fb17e97936dde5bf6", size = 220001, upload-time = "2025-12-28T15:42:31.319Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d7/50de63af51dfa3a7f91cc37ad8fcc1e244b734232fbc8b9ab0f3c834a5cd/coverage-7.13.1-cp314-cp314t-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:3f2f725aa3e909b3c5fdb8192490bdd8e1495e85906af74fe6e34a2a77ba0673", size = 261370, upload-time = "2025-12-28T15:42:32.992Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/2c/d31722f0ec918fd7453b2758312729f645978d212b410cd0f7c2aed88a94/coverage-7.13.1-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9ee68b21909686eeb21dfcba2c3b81fee70dcf38b140dcd5aa70680995fa3aa5", size = 263485, upload-time = "2025-12-28T15:42:34.759Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/7a/2c114fa5c5fc08ba0777e4aec4c97e0b4a1afcb69c75f1f54cff78b073ab/coverage-7.13.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:724b1b270cb13ea2e6503476e34541a0b1f62280bc997eab443f87790202033d", size = 265890, upload-time = "2025-12-28T15:42:36.517Z" },
+    { url = "https://files.pythonhosted.org/packages/65/d9/f0794aa1c74ceabc780fe17f6c338456bbc4e96bd950f2e969f48ac6fb20/coverage-7.13.1-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:916abf1ac5cf7eb16bc540a5bf75c71c43a676f5c52fcb9fe75a2bd75fb944e8", size = 260445, upload-time = "2025-12-28T15:42:38.646Z" },
+    { url = "https://files.pythonhosted.org/packages/49/23/184b22a00d9bb97488863ced9454068c79e413cb23f472da6cbddc6cfc52/coverage-7.13.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:776483fd35b58d8afe3acbd9988d5de592ab6da2d2a865edfdbc9fdb43e7c486", size = 263357, upload-time = "2025-12-28T15:42:40.788Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/bd/58af54c0c9199ea4190284f389005779d7daf7bf3ce40dcd2d2b2f96da69/coverage-7.13.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:b6f3b96617e9852703f5b633ea01315ca45c77e879584f283c44127f0f1ec564", size = 260959, upload-time = "2025-12-28T15:42:42.808Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2a/6839294e8f78a4891bf1df79d69c536880ba2f970d0ff09e7513d6e352e9/coverage-7.13.1-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:bd63e7b74661fed317212fab774e2a648bc4bb09b35f25474f8e3325d2945cd7", size = 259792, upload-time = "2025-12-28T15:42:44.818Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/c3/528674d4623283310ad676c5af7414b9850ab6d55c2300e8aa4b945ec554/coverage-7.13.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:933082f161bbb3e9f90d00990dc956120f608cdbcaeea15c4d897f56ef4fe416", size = 262123, upload-time = "2025-12-28T15:42:47.108Z" },
+    { url = "https://files.pythonhosted.org/packages/06/c5/8c0515692fb4c73ac379d8dc09b18eaf0214ecb76ea6e62467ba7a1556ff/coverage-7.13.1-cp314-cp314t-win32.whl", hash = "sha256:18be793c4c87de2965e1c0f060f03d9e5aff66cfeae8e1dbe6e5b88056ec153f", size = 222562, upload-time = "2025-12-28T15:42:49.144Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0e/c0a0c4678cb30dac735811db529b321d7e1c9120b79bd728d4f4d6b010e9/coverage-7.13.1-cp314-cp314t-win_amd64.whl", hash = "sha256:0e42e0ec0cd3e0d851cb3c91f770c9301f48647cb2877cb78f74bdaa07639a79", size = 223670, upload-time = "2025-12-28T15:42:51.218Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/5f/b177aa0011f354abf03a8f30a85032686d290fdeed4222b27d36b4372a50/coverage-7.13.1-cp314-cp314t-win_arm64.whl", hash = "sha256:eaecf47ef10c72ece9a2a92118257da87e460e113b83cc0d2905cbbe931792b4", size = 221707, upload-time = "2025-12-28T15:42:53.034Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/48/d9f421cb8da5afaa1a64570d9989e00fb7955e6acddc5a12979f7666ef60/coverage-7.13.1-py3-none-any.whl", hash = "sha256:2016745cb3ba554469d02819d78958b571792bb68e31302610e898f80dd3a573", size = 210722, upload-time = "2025-12-28T15:42:54.901Z" },
+]
+
+[package.optional-dependencies]
+toml = [
+    { name = "tomli", marker = "python_full_version <= '3.11'" },
+]
+
+[[package]]
 name = "cryptography"
 version = "46.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -586,6 +678,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
 ]
 
 [[package]]
@@ -1130,6 +1231,7 @@ version = "0.1.0"
 source = { editable = "packages/pitlane-agent" }
 dependencies = [
     { name = "claude-agent-sdk" },
+    { name = "click" },
     { name = "fastf1" },
     { name = "matplotlib" },
     { name = "numpy" },
@@ -1138,6 +1240,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "claude-agent-sdk" },
+    { name = "click", specifier = ">=8.1.0" },
     { name = "fastf1", specifier = ">=3.0" },
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.24" },
@@ -1150,13 +1253,23 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-cov" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
 [package.metadata]
 
 [package.metadata.requires-dev]
-dev = [{ name = "ruff", specifier = ">=0.8.4" }]
+dev = [
+    { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-asyncio", specifier = ">=0.24" },
+    { name = "pytest-cov", specifier = ">=4.1" },
+    { name = "pytest-mock", specifier = ">=3.12" },
+    { name = "ruff", specifier = ">=0.8.4" },
+]
 
 [[package]]
 name = "pitlane-web"
@@ -1188,6 +1301,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cf/86/0248f086a84f01b37aaec0fa567b397df1a119f73c16f6c7a9aac73ea309/platformdirs-4.5.1.tar.gz", hash = "sha256:61d5cdcc6065745cdd94f0f878977f8de9437be93de97c1c12f853c9c0cdcbda", size = 21715, upload-time = "2025-12-05T13:52:58.638Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/28/3bfe2fa5a7b9c46fe7e13c97bda14c895fb10fa2ebf1d0abb90e0cea7ee1/platformdirs-4.5.1-py3-none-any.whl", hash = "sha256:d03afa3963c806a9bed9d5125c8f4cb2fdaf74a55ab60e5d59b3fde758104d31", size = 18731, upload-time = "2025-12-05T13:52:56.823Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
 ]
 
 [[package]]
@@ -1326,6 +1448,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pygments"
+version = "2.19.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
 name = "pyjwt"
 version = "2.10.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1346,6 +1477,61 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d1/db/7ef3487e0fb0049ddb5ce41d3a49c235bf9ad299b6a25d5780a89f19230f/pytest-9.0.2.tar.gz", hash = "sha256:75186651a92bd89611d1d9fc20f0b4345fd827c41ccd5c299a868a05d70edf11", size = 1568901, upload-time = "2025-12-06T21:30:51.014Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/ab/b3226f0bd7cdcf710fbede2b3548584366da3b19b5021e74f5bde2a8fa3f/pytest-9.0.2-py3-none-any.whl", hash = "sha256:711ffd45bf766d5264d487b917733b453d917afd2b0ad65223959f59089f875b", size = 374801, upload-time = "2025-12-06T21:30:49.154Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage", extra = ["toml"] },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5e/f7/c933acc76f5208b3b00089573cf6a2bc26dc80a8aece8f52bb7d6b1855ca/pytest_cov-7.0.0.tar.gz", hash = "sha256:33c97eda2e049a0c5298e91f519302a1334c26ac65c1a483d6206fd458361af1", size = 54328, upload-time = "2025-09-09T10:57:02.113Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ee/49/1377b49de7d0c1ce41292161ea0f721913fa8722c19fb9c1e3aa0367eecb/pytest_cov-7.0.0-py3-none-any.whl", hash = "sha256:3b8e9558b16cc1479da72058bdecf8073661c7f57f7d3c5f22a1c23507f2d861", size = 22424, upload-time = "2025-09-09T10:57:00.695Z" },
+]
+
+[[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
 ]
 
 [[package]]
@@ -1849,6 +2035,60 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/92/69/728b57ee09a36a228f9f5e399eff5e8e8f4e32e3e366b57f56649a3eff28/timple-0.1.8.tar.gz", hash = "sha256:bbc120300f0103a3a93e54a0d00491c4b70872fe69b11204701a4889c6a05f0f", size = 17277, upload-time = "2023-12-27T11:38:20.477Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/45/c73f9af9a9d50b0ae972d185ef2255c62524d1aa20a76531dd2fcda48819/timple-0.1.8-py3-none-any.whl", hash = "sha256:195a49e76f8a435e0bc079340b6c57272cc3aff9041f61f8858790d607a4e49d", size = 17824, upload-time = "2023-12-27T11:38:18.835Z" },
+]
+
+[[package]]
+name = "tomli"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/30/31573e9457673ab10aa432461bee537ce6cef177667deca369efb79df071/tomli-2.4.0.tar.gz", hash = "sha256:aa89c3f6c277dd275d8e243ad24f3b5e701491a860d5121f2cdd399fbb31fc9c", size = 17477, upload-time = "2026-01-11T11:22:38.165Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/d9/3dc2289e1f3b32eb19b9785b6a006b28ee99acb37d1d47f78d4c10e28bf8/tomli-2.4.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:b5ef256a3fd497d4973c11bf142e9ed78b150d36f5773f1ca6088c230ffc5867", size = 153663, upload-time = "2026-01-11T11:21:45.27Z" },
+    { url = "https://files.pythonhosted.org/packages/51/32/ef9f6845e6b9ca392cd3f64f9ec185cc6f09f0a2df3db08cbe8809d1d435/tomli-2.4.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:5572e41282d5268eb09a697c89a7bee84fae66511f87533a6f88bd2f7b652da9", size = 148469, upload-time = "2026-01-11T11:21:46.873Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/c2/506e44cce89a8b1b1e047d64bd495c22c9f71f21e05f380f1a950dd9c217/tomli-2.4.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:551e321c6ba03b55676970b47cb1b73f14a0a4dce6a3e1a9458fd6d921d72e95", size = 236039, upload-time = "2026-01-11T11:21:48.503Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/40/e1b65986dbc861b7e986e8ec394598187fa8aee85b1650b01dd925ca0be8/tomli-2.4.0-cp311-cp311-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5e3f639a7a8f10069d0e15408c0b96a2a828cfdec6fca05296ebcdcc28ca7c76", size = 243007, upload-time = "2026-01-11T11:21:49.456Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/6f/6e39ce66b58a5b7ae572a0f4352ff40c71e8573633deda43f6a379d56b3e/tomli-2.4.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:1b168f2731796b045128c45982d3a4874057626da0e2ef1fdd722848b741361d", size = 240875, upload-time = "2026-01-11T11:21:50.755Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ad/cb089cb190487caa80204d503c7fd0f4d443f90b95cf4ef5cf5aa0f439b0/tomli-2.4.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:133e93646ec4300d651839d382d63edff11d8978be23da4cc106f5a18b7d0576", size = 246271, upload-time = "2026-01-11T11:21:51.81Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/69125220e47fd7a3a27fd0de0c6398c89432fec41bc739823bcc66506af6/tomli-2.4.0-cp311-cp311-win32.whl", hash = "sha256:b6c78bdf37764092d369722d9946cb65b8767bfa4110f902a1b2542d8d173c8a", size = 96770, upload-time = "2026-01-11T11:21:52.647Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/0d/a22bb6c83f83386b0008425a6cd1fa1c14b5f3dd4bad05e98cf3dbbf4a64/tomli-2.4.0-cp311-cp311-win_amd64.whl", hash = "sha256:d3d1654e11d724760cdb37a3d7691f0be9db5fbdaef59c9f532aabf87006dbaa", size = 107626, upload-time = "2026-01-11T11:21:53.459Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/6d/77be674a3485e75cacbf2ddba2b146911477bd887dda9d8c9dfb2f15e871/tomli-2.4.0-cp311-cp311-win_arm64.whl", hash = "sha256:cae9c19ed12d4e8f3ebf46d1a75090e4c0dc16271c5bce1c833ac168f08fb614", size = 94842, upload-time = "2026-01-11T11:21:54.831Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/43/7389a1869f2f26dba52404e1ef13b4784b6b37dac93bac53457e3ff24ca3/tomli-2.4.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:920b1de295e72887bafa3ad9f7a792f811847d57ea6b1215154030cf131f16b1", size = 154894, upload-time = "2026-01-11T11:21:56.07Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/05/2f9bf110b5294132b2edf13fe6ca6ae456204f3d749f623307cbb7a946f2/tomli-2.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7d6d9a4aee98fac3eab4952ad1d73aee87359452d1c086b5ceb43ed02ddb16b8", size = 149053, upload-time = "2026-01-11T11:21:57.467Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/41/1eda3ca1abc6f6154a8db4d714a4d35c4ad90adc0bcf700657291593fbf3/tomli-2.4.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:36b9d05b51e65b254ea6c2585b59d2c4cb91c8a3d91d0ed0f17591a29aaea54a", size = 243481, upload-time = "2026-01-11T11:21:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/6d/02ff5ab6c8868b41e7d4b987ce2b5f6a51d3335a70aa144edd999e055a01/tomli-2.4.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1c8a885b370751837c029ef9bc014f27d80840e48bac415f3412e6593bbc18c1", size = 251720, upload-time = "2026-01-11T11:22:00.178Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/57/0405c59a909c45d5b6f146107c6d997825aa87568b042042f7a9c0afed34/tomli-2.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8768715ffc41f0008abe25d808c20c3d990f42b6e2e58305d5da280ae7d1fa3b", size = 247014, upload-time = "2026-01-11T11:22:01.238Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/0e/2e37568edd944b4165735687cbaf2fe3648129e440c26d02223672ee0630/tomli-2.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:7b438885858efd5be02a9a133caf5812b8776ee0c969fea02c45e8e3f296ba51", size = 251820, upload-time = "2026-01-11T11:22:02.727Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1c/ee3b707fdac82aeeb92d1a113f803cf6d0f37bdca0849cb489553e1f417a/tomli-2.4.0-cp312-cp312-win32.whl", hash = "sha256:0408e3de5ec77cc7f81960c362543cbbd91ef883e3138e81b729fc3eea5b9729", size = 97712, upload-time = "2026-01-11T11:22:03.777Z" },
+    { url = "https://files.pythonhosted.org/packages/69/13/c07a9177d0b3bab7913299b9278845fc6eaaca14a02667c6be0b0a2270c8/tomli-2.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:685306e2cc7da35be4ee914fd34ab801a6acacb061b6a7abca922aaf9ad368da", size = 108296, upload-time = "2026-01-11T11:22:04.86Z" },
+    { url = "https://files.pythonhosted.org/packages/18/27/e267a60bbeeee343bcc279bb9e8fbed0cbe224bc7b2a3dc2975f22809a09/tomli-2.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:5aa48d7c2356055feef06a43611fc401a07337d5b006be13a30f6c58f869e3c3", size = 94553, upload-time = "2026-01-11T11:22:05.854Z" },
+    { url = "https://files.pythonhosted.org/packages/34/91/7f65f9809f2936e1f4ce6268ae1903074563603b2a2bd969ebbda802744f/tomli-2.4.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:84d081fbc252d1b6a982e1870660e7330fb8f90f676f6e78b052ad4e64714bf0", size = 154915, upload-time = "2026-01-11T11:22:06.703Z" },
+    { url = "https://files.pythonhosted.org/packages/20/aa/64dd73a5a849c2e8f216b755599c511badde80e91e9bc2271baa7b2cdbb1/tomli-2.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:9a08144fa4cba33db5255f9b74f0b89888622109bd2776148f2597447f92a94e", size = 149038, upload-time = "2026-01-11T11:22:07.56Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8a/6d38870bd3d52c8d1505ce054469a73f73a0fe62c0eaf5dddf61447e32fa/tomli-2.4.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c73add4bb52a206fd0c0723432db123c0c75c280cbd67174dd9d2db228ebb1b4", size = 242245, upload-time = "2026-01-11T11:22:08.344Z" },
+    { url = "https://files.pythonhosted.org/packages/59/bb/8002fadefb64ab2669e5b977df3f5e444febea60e717e755b38bb7c41029/tomli-2.4.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:1fb2945cbe303b1419e2706e711b7113da57b7db31ee378d08712d678a34e51e", size = 250335, upload-time = "2026-01-11T11:22:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/3d/4cdb6f791682b2ea916af2de96121b3cb1284d7c203d97d92d6003e91c8d/tomli-2.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bbb1b10aa643d973366dc2cb1ad94f99c1726a02343d43cbc011edbfac579e7c", size = 245962, upload-time = "2026-01-11T11:22:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/4a/5f25789f9a460bd858ba9756ff52d0830d825b458e13f754952dd15fb7bb/tomli-2.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:4cbcb367d44a1f0c2be408758b43e1ffb5308abe0ea222897d6bfc8e8281ef2f", size = 250396, upload-time = "2026-01-11T11:22:12.325Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2f/b73a36fea58dfa08e8b3a268750e6853a6aac2a349241a905ebd86f3047a/tomli-2.4.0-cp313-cp313-win32.whl", hash = "sha256:7d49c66a7d5e56ac959cb6fc583aff0651094ec071ba9ad43df785abc2320d86", size = 97530, upload-time = "2026-01-11T11:22:13.865Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/af/ca18c134b5d75de7e8dc551c5234eaba2e8e951f6b30139599b53de9c187/tomli-2.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:3cf226acb51d8f1c394c1b310e0e0e61fecdd7adcb78d01e294ac297dd2e7f87", size = 108227, upload-time = "2026-01-11T11:22:15.224Z" },
+    { url = "https://files.pythonhosted.org/packages/22/c3/b386b832f209fee8073c8138ec50f27b4460db2fdae9ffe022df89a57f9b/tomli-2.4.0-cp313-cp313-win_arm64.whl", hash = "sha256:d20b797a5c1ad80c516e41bc1fb0443ddb5006e9aaa7bda2d71978346aeb9132", size = 94748, upload-time = "2026-01-11T11:22:16.009Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c4/84047a97eb1004418bc10bdbcfebda209fca6338002eba2dc27cc6d13563/tomli-2.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:26ab906a1eb794cd4e103691daa23d95c6919cc2fa9160000ac02370cc9dd3f6", size = 154725, upload-time = "2026-01-11T11:22:17.269Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/5d/d39038e646060b9d76274078cddf146ced86dc2b9e8bbf737ad5983609a0/tomli-2.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:20cedb4ee43278bc4f2fee6cb50daec836959aadaf948db5172e776dd3d993fc", size = 148901, upload-time = "2026-01-11T11:22:18.287Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e5/383be1724cb30f4ce44983d249645684a48c435e1cd4f8b5cded8a816d3c/tomli-2.4.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:39b0b5d1b6dd03684b3fb276407ebed7090bbec989fa55838c98560c01113b66", size = 243375, upload-time = "2026-01-11T11:22:19.154Z" },
+    { url = "https://files.pythonhosted.org/packages/31/f0/bea80c17971c8d16d3cc109dc3585b0f2ce1036b5f4a8a183789023574f2/tomli-2.4.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a26d7ff68dfdb9f87a016ecfd1e1c2bacbe3108f4e0f8bcd2228ef9a766c787d", size = 250639, upload-time = "2026-01-11T11:22:20.168Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/8f/2853c36abbb7608e3f945d8a74e32ed3a74ee3a1f468f1ffc7d1cb3abba6/tomli-2.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:20ffd184fb1df76a66e34bd1b36b4a4641bd2b82954befa32fe8163e79f1a702", size = 246897, upload-time = "2026-01-11T11:22:21.544Z" },
+    { url = "https://files.pythonhosted.org/packages/49/f0/6c05e3196ed5337b9fe7ea003e95fd3819a840b7a0f2bf5a408ef1dad8ed/tomli-2.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:75c2f8bbddf170e8effc98f5e9084a8751f8174ea6ccf4fca5398436e0320bc8", size = 254697, upload-time = "2026-01-11T11:22:23.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f5/2922ef29c9f2951883525def7429967fc4d8208494e5ab524234f06b688b/tomli-2.4.0-cp314-cp314-win32.whl", hash = "sha256:31d556d079d72db7c584c0627ff3a24c5d3fb4f730221d3444f3efb1b2514776", size = 98567, upload-time = "2026-01-11T11:22:24.033Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/31/22b52e2e06dd2a5fdbc3ee73226d763b184ff21fc24e20316a44ccc4d96b/tomli-2.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:43e685b9b2341681907759cf3a04e14d7104b3580f808cfde1dfdb60ada85475", size = 108556, upload-time = "2026-01-11T11:22:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/48/3d/5058dff3255a3d01b705413f64f4306a141a8fd7a251e5a495e3f192a998/tomli-2.4.0-cp314-cp314-win_arm64.whl", hash = "sha256:3d895d56bd3f82ddd6faaff993c275efc2ff38e52322ea264122d72729dca2b2", size = 96014, upload-time = "2026-01-11T11:22:26.138Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/4e/75dab8586e268424202d3a1997ef6014919c941b50642a1682df43204c22/tomli-2.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:5b5807f3999fb66776dbce568cc9a828544244a8eb84b84b9bafc080c99597b9", size = 163339, upload-time = "2026-01-11T11:22:27.143Z" },
+    { url = "https://files.pythonhosted.org/packages/06/e3/b904d9ab1016829a776d97f163f183a48be6a4deb87304d1e0116a349519/tomli-2.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c084ad935abe686bd9c898e62a02a19abfc9760b5a79bc29644463eaf2840cb0", size = 159490, upload-time = "2026-01-11T11:22:28.399Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/5a/fc3622c8b1ad823e8ea98a35e3c632ee316d48f66f80f9708ceb4f2a0322/tomli-2.4.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0f2e3955efea4d1cfbcb87bc321e00dc08d2bcb737fd1d5e398af111d86db5df", size = 269398, upload-time = "2026-01-11T11:22:29.345Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/33/62bd6152c8bdd4c305ad9faca48f51d3acb2df1f8791b1477d46ff86e7f8/tomli-2.4.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0e0fe8a0b8312acf3a88077a0802565cb09ee34107813bba1c7cd591fa6cfc8d", size = 276515, upload-time = "2026-01-11T11:22:30.327Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ff/ae53619499f5235ee4211e62a8d7982ba9e439a0fb4f2f351a93d67c1dd2/tomli-2.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:413540dce94673591859c4c6f794dfeaa845e98bf35d72ed59636f869ef9f86f", size = 273806, upload-time = "2026-01-11T11:22:32.56Z" },
+    { url = "https://files.pythonhosted.org/packages/47/71/cbca7787fa68d4d0a9f7072821980b39fbb1b6faeb5f5cf02f4a5559fa28/tomli-2.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0dc56fef0e2c1c470aeac5b6ca8cc7b640bb93e92d9803ddaf9ea03e198f5b0b", size = 281340, upload-time = "2026-01-11T11:22:33.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/00/d595c120963ad42474cf6ee7771ad0d0e8a49d0f01e29576ee9195d9ecdf/tomli-2.4.0-cp314-cp314t-win32.whl", hash = "sha256:d878f2a6707cc9d53a1be1414bbb419e629c3d6e67f69230217bb663e76b5087", size = 108106, upload-time = "2026-01-11T11:22:34.451Z" },
+    { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
+    { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

This PR refactors all CLI scripts from argparse to click, creates a unified `pitlane` command interface, and adds comprehensive test coverage (96%) with a focus on testability.

## Changes

### CLI Refactoring
- ✅ Migrated `session_info.py`, `tyre_strategy.py`, and `lap_times.py` from argparse to click
- ✅ Created unified `pitlane` command with subcommands (`lap-times`, `session-info`, `tyre-strategy`)
- ✅ Added CLI entry point in pyproject.toml
- ✅ Maintained backward compatibility for module invocation (`python -m pitlane_agent.scripts.*`)

### Dependencies
- ✅ Added `click>=8.1.0` to pitlane-agent
- ✅ Added `pytest-asyncio>=0.24`, `pytest>=8.0`, `pytest-cov>=4.1`, `pytest-mock>=3.12` to dev dependencies

### Test Suite (43 tests, 96% coverage)
- ✅ **Agent tests**: 14 tests, 100% coverage on agent.py
  - Initialization with default/custom charts directories
  - Async chat methods with proper mocking
  - Message filtering and text block handling
  
- ✅ **Script tests**: 29 tests, 95% coverage
  - Unit tests for business logic (mocked FastF1 and matplotlib)
  - CLI integration tests using `click.testing.CliRunner`
  - Error handling and validation
  
- ✅ **CLI group tests**: 5 tests
  - Main help output and subcommand registration
  - Individual subcommand help verification

### Code Structure
- Business logic completely unchanged (pure functions)
- CLI adapters use click decorators
- Excellent separation of concerns for testability

## Breaking Changes

⚠️ **`lap_times.py` driver argument syntax changed**:
- **Old**: `--drivers VER HAM LEC` (space-separated)
- **New**: `--drivers VER --drivers HAM --drivers LEC` (repeated options)

This follows click conventions and provides better validation.

## Usage Examples

```bash
# Unified CLI (recommended)
uv run pitlane --help
uv run pitlane session-info --year 2024 --gp Monaco --session R
uv run pitlane lap-times --year 2024 --gp Monaco --session Q --drivers VER --drivers HAM
uv run pitlane tyre-strategy --year 2024 --gp Monaco --session R

# Module invocation still works (backward compatible)
python -m pitlane_agent.scripts.session_info --help
python -m pitlane_agent.cli lap-times --help
```

## Testing

All tests passing:
```bash
uv run python -m pytest -v
# 43 passed in 31.84s

uv run python -m pytest --cov=pitlane_agent --cov-report=term-missing
# 96% coverage
```

## Verification

- [x] All existing tests pass
- [x] New tests added with high coverage
- [x] CLI commands work as expected
- [x] Module invocation still works
- [x] Code follows project style (ruff compliant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)