### PR TITLE
fix: use pd.notna() for proper pandas null checks in scripts

### DIFF
--- a/packages/pitlane-agent/src/pitlane_agent/scripts/event_schedule.py
+++ b/packages/pitlane-agent/src/pitlane_agent/scripts/event_schedule.py
@@ -12,6 +12,7 @@ from datetime import datetime
 
 import click
 import fastf1
+import pandas as pd
 
 
 def get_event_schedule(
@@ -48,12 +49,12 @@ def get_event_schedule(
 
         # Build event dict with all relevant fields
         event_data = {
-            "round": int(event["RoundNumber"]) if event["RoundNumber"] else 0,
+            "round": int(event["RoundNumber"]) if pd.notna(event["RoundNumber"]) else 0,
             "country": event["Country"],
             "location": event["Location"],
             "official_name": event["OfficialEventName"],
             "event_name": event["EventName"],
-            "event_date": event["EventDate"].isoformat() if event["EventDate"] else None,
+            "event_date": event["EventDate"].isoformat() if pd.notna(event["EventDate"]) else None,
             "event_format": event["EventFormat"],
             "f1_api_support": bool(event["F1ApiSupport"]),
             "sessions": [],
@@ -70,17 +71,15 @@ def get_event_schedule(
             if session_name and session_name != "" and str(session_name) != "None":
                 # Check if session date is valid (not NaT)
                 session_date = event.get(session_date_key)
-                if session_date is not None and str(session_date) != "NaT":
+                if pd.notna(session_date):
                     session_info = {
                         "name": session_name,
                         "date_local": (
-                            event[session_date_key].isoformat()
-                            if event.get(session_date_key)
-                            else None
+                            event[session_date_key].isoformat() if pd.notna(event.get(session_date_key)) else None
                         ),
                         "date_utc": (
                             event[session_date_utc_key].isoformat()
-                            if event.get(session_date_utc_key)
+                            if pd.notna(event.get(session_date_utc_key))
                             else None
                         ),
                     }

--- a/packages/pitlane-agent/src/pitlane_agent/scripts/session_info.py
+++ b/packages/pitlane-agent/src/pitlane_agent/scripts/session_info.py
@@ -12,6 +12,7 @@ import sys
 
 import click
 import fastf1
+import pandas as pd
 
 
 def get_session_info(year: int, gp: str, session_type: str) -> dict:
@@ -40,8 +41,8 @@ def get_session_info(year: int, gp: str, session_type: str) -> dict:
                 "abbreviation": driver["Abbreviation"],
                 "name": f"{driver['FirstName']} {driver['LastName']}",
                 "team": driver["TeamName"],
-                "number": int(driver["DriverNumber"]) if driver["DriverNumber"] else None,
-                "position": int(driver["Position"]) if driver["Position"] else None,
+                "number": int(driver["DriverNumber"]) if pd.notna(driver["DriverNumber"]) else None,
+                "position": int(driver["Position"]) if pd.notna(driver["Position"]) else None,
             }
         )
 
@@ -51,8 +52,10 @@ def get_session_info(year: int, gp: str, session_type: str) -> dict:
         "country": session.event["Country"],
         "session_type": session_type,
         "session_name": session.name,
-        "date": str(session.date.date()) if session.date else None,
-        "total_laps": int(session.total_laps) if hasattr(session, "total_laps") else None,
+        "date": str(session.date.date()) if pd.notna(session.date) else None,
+        "total_laps": int(session.total_laps)
+        if hasattr(session, "total_laps") and pd.notna(session.total_laps)
+        else None,
         "drivers": drivers,
     }
 

--- a/packages/pitlane-agent/src/pitlane_agent/scripts/tyre_strategy.py
+++ b/packages/pitlane-agent/src/pitlane_agent/scripts/tyre_strategy.py
@@ -17,6 +17,7 @@ import click
 import fastf1
 import fastf1.plotting
 import matplotlib.pyplot as plt
+import pandas as pd
 
 # Tyre compound colors (F1 2024 style)
 COMPOUND_COLORS = {
@@ -125,7 +126,7 @@ def generate_tyre_strategy_chart(
 
         # Draw stints as horizontal bars
         for stint in stints:
-            compound = stint["compound"] if stint["compound"] else "UNKNOWN"
+            compound = stint["compound"] if pd.notna(stint["compound"]) else "UNKNOWN"
             color = COMPOUND_COLORS.get(compound.upper(), COMPOUND_COLORS["UNKNOWN"])
 
             ax.barh(
@@ -189,7 +190,9 @@ def generate_tyre_strategy_chart(
         "event_name": session.event["EventName"],
         "session_name": session.name,
         "year": year,
-        "total_laps": int(session.total_laps) if hasattr(session, "total_laps") else None,
+        "total_laps": int(session.total_laps)
+        if hasattr(session, "total_laps") and pd.notna(session.total_laps)
+        else None,
         "strategies": strategies,
     }
 


### PR DESCRIPTION
## Summary
- Replace truthiness checks with `pd.notna()` to correctly handle pandas NA/NaT values in DataFrames
- Fixes potential `TypeError` when encountering missing data in pandas objects
- Ensures consistent null handling across all F1 data scripts

## Problem
The previous implementation used truthiness checks (e.g., `if driver["DriverNumber"]`) which are incorrect for pandas because:
- `pd.NA` evaluates to `True` in boolean context
- `pd.NaT` (Not-a-Time) also evaluates to `True`
- This would cause `int(pd.NA)` to be called, raising a `TypeError: int() argument must be a string, a bytes-like object or a real number, not 'NoneType'`

## Changes
- **session_info.py**: Fix null checks for driver numbers, positions, dates, and total laps
- **event_schedule.py**: Fix null checks for round numbers, event dates, and session dates  
- **tyre_strategy.py**: Fix null checks for tyre compounds and total laps

## Test plan
- [x] Run session_info script with sessions that have missing driver data
- [x] Run event_schedule script with events that have missing session dates
- [x] Run tyre_strategy script with races that have incomplete tyre data
- [x] Verify no TypeErrors are raised when encountering pd.NA or pd.NaT values

🤖 Generated with [Claude Code](https://claude.com/claude-code)