### PR TITLE
fix: support pre-release versions in bump_version.py

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -9,9 +9,13 @@ This script updates the version number in all 5 locations:
 4. /packages/pitlane-agent/src/pitlane_agent/__init__.py
 5. /packages/pitlane-web/src/pitlane_web/__init__.py
 
+Supports full semantic versioning including pre-release and build metadata.
+
 Usage:
     python scripts/bump_version.py 0.2.0
-    python scripts/bump_version.py v0.2.0  # 'v' prefix is automatically stripped
+    python scripts/bump_version.py v0.2.0        # 'v' prefix is automatically stripped
+    python scripts/bump_version.py 0.2.0-beta    # Pre-release version
+    python scripts/bump_version.py 0.2.0-rc.1    # Release candidate
 """
 
 import re
@@ -23,8 +27,14 @@ def validate_version(version: str) -> str:
     """
     Validate and normalize semantic version format.
 
+    Supports full semantic versioning including pre-release and build metadata:
+    - 0.2.0
+    - 0.2.0-beta
+    - 0.2.0-beta.1
+    - 0.2.0-rc.1+build.123
+
     Args:
-        version: Version string (e.g., "0.2.0" or "v0.2.0")
+        version: Version string (e.g., "0.2.0", "v0.2.0-beta", "0.2.0-rc.1")
 
     Returns:
         Normalized version string without 'v' prefix
@@ -35,11 +45,14 @@ def validate_version(version: str) -> str:
     # Strip 'v' prefix if present
     normalized = version.lstrip("v")
 
-    # Validate semantic version format (X.Y.Z)
-    pattern = r"^\d+\.\d+\.\d+$"
+    # Validate semantic version format (X.Y.Z[-prerelease][+build])
+    # Based on https://semver.org/
+    pattern = r"^\d+\.\d+\.\d+(-[\w\.-]+)?(\+[\w\.-]+)?$"
     if not re.match(pattern, normalized):
         raise ValueError(
-            f"Invalid version format: {version}. " f"Expected semantic version format: X.Y.Z (e.g., 0.2.0)"
+            f"Invalid version format: {version}. "
+            f"Expected semantic version format: X.Y.Z[-prerelease][+build] "
+            f"(e.g., 0.2.0, 0.2.0-beta, 0.2.0-rc.1)"
         )
 
     return normalized


### PR DESCRIPTION
## Problem

The `bump_version.py` script was failing with pre-release versions like `v0.1.1-test` because the validation regex only accepted strict semantic versioning (X.Y.Z).

Error encountered:
```
✗ Validation error: Invalid version format: 0.1.1-test. 
Expected semantic version format: X.Y.Z (e.g., 0.2.0)
```

## Solution

Updated the validation regex to support full semantic versioning spec including:
- Pre-release tags: `0.1.1-test`, `0.2.0-beta`, `0.2.0-rc.1`
- Build metadata: `0.2.0+build.123`
- Combined: `0.2.0-rc.1+build.123`

## Changes

- Updated regex pattern from `^\d+\.\d+\.\d+$` to `^\d+\.\d+\.\d+(-[\w\.-]+)?(\+[\w\.-]+)?$`
- Enhanced validation error message to show examples
- Updated documentation with pre-release examples

## Testing

```bash
# All these now work:
python scripts/bump_version.py 0.1.1-test     # ✓
python scripts/bump_version.py v0.2.0-beta    # ✓
python scripts/bump_version.py 0.2.0-rc.1     # ✓
python scripts/bump_version.py 0.2.0          # ✓ (still works)
```

This allows testing the release workflow with tags like `v0.1.1-test` before creating production releases.