### PR TITLE
chore: add conventional commits pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 repos:
   # Ruff - Python linting and formatting
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.4
+    rev: v0.14.14
     hooks:
       - id: ruff
         args: [--fix]
@@ -9,7 +9,7 @@ repos:
 
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: check-yaml
       - id: check-toml
@@ -20,3 +20,11 @@ repos:
         args: ['--maxkb=500']
       - id: check-merge-conflict
       - id: detect-private-key
+
+  # Conventional Commits
+  - repo: https://github.com/compilerla/conventional-pre-commit
+    rev: v4.3.0
+    hooks:
+      - id: conventional-pre-commit
+        stages: [commit-msg]
+        args: []


### PR DESCRIPTION
## Summary
- Adds conventional commits validation via pre-commit hook
- Ensures all commit messages follow the [Conventional Commits](https://www.conventionalcommits.org/) specification
- Updates all pre-commit hooks to their latest versions

## Changes
- Added `conventional-pre-commit` hook to `.pre-commit-config.yaml`
- Installed commit-msg hook in git repository
- Updated dependencies:
  - ruff: v0.8.4 → v0.14.14
  - pre-commit-hooks: v5.0.0 → v6.0.0
  - conventional-pre-commit: v4.3.0 (new)

## Commit Message Format
Commits must now follow this format:
```
<type>[optional scope]: <description>
```

Valid types: `feat`, `fix`, `docs`, `style`, `refactor`, `perf`, `test`, `build`, `ci`, `chore`, `revert`

## Test plan
- [x] Hook validates commit messages correctly
- [x] Conventional commit message passed validation
- [x] Pre-commit hooks updated successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)