### PR TITLE
Fix dependency group in docs deployment workflow

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -41,7 +41,7 @@ jobs:
         run: uv python install 3.12
 
       - name: Install dependencies
-        run: uv sync --dev
+        run: uv sync --group docs
 
       - name: Configure Git for git-revision-date-localized
         run: |


### PR DESCRIPTION
## Summary
- Fix uv sync command to use `--group docs` instead of `--dev` for proper documentation dependency installation

## Test plan
- [x] Verify GitHub Actions workflow runs successfully with correct dependencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)