### PR TITLE
docs: fix broken links and update PyPI badges

### DIFF
--- a/docs/architecture/agent-system.md
+++ b/docs/architecture/agent-system.md
@@ -31,7 +31,7 @@ The core agent architecture consists of three main components:
 
 ## F1Agent Class
 
-The [`F1Agent`](../../packages/pitlane-agent/src/pitlane_agent/agent.py) class is the primary interface for interacting with the AI agent.
+The [`F1Agent`](https://github.com/jshudzina/PitLane-AI/blob/main/packages/pitlane-agent/src/pitlane_agent/agent.py) class is the primary interface for interacting with the AI agent.
 
 ### Initialization
 

--- a/docs/architecture/tool-permissions.md
+++ b/docs/architecture/tool-permissions.md
@@ -243,7 +243,7 @@ Trace output example:
 
 ## Implementation
 
-See [`tool_permissions.py`](../../packages/pitlane-agent/src/pitlane_agent/tool_permissions.py) for the full implementation:
+See [`tool_permissions.py`](https://github.com/jshudzina/PitLane-AI/blob/main/packages/pitlane-agent/src/pitlane_agent/tool_permissions.py) for the full implementation:
 
 ```python
 async def can_use_tool(

--- a/docs/architecture/workspace-management.md
+++ b/docs/architecture/workspace-management.md
@@ -140,7 +140,7 @@ This enables:
 
 ## Workspace API
 
-See [`scripts/workspace.py`](../../packages/pitlane-agent/src/pitlane_agent/scripts/workspace.py) for the full API:
+See [`scripts/workspace.py`](https://github.com/jshudzina/PitLane-AI/blob/main/packages/pitlane-agent/src/pitlane_agent/scripts/workspace.py) for the full API:
 
 ### Create Workspace
 

--- a/docs/developer-guide/release-process.md
+++ b/docs/developer-guide/release-process.md
@@ -1,6 +1,6 @@
 # Release Process
 
-Detailed release process documentation can be found at [docs/RELEASE_PROCESS.md](../../RELEASE_PROCESS.md).
+Detailed release process documentation can be found at [docs/RELEASE_PROCESS.md](../RELEASE_PROCESS.md).
 
 ## Quick Reference
 
@@ -27,4 +27,4 @@ Follow [Semantic Versioning](https://semver.org/):
 - **MINOR**: New features (backward compatible)
 - **PATCH**: Bug fixes
 
-See [full documentation](../../RELEASE_PROCESS.md) for details.
+See [full documentation](../RELEASE_PROCESS.md) for details.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,8 +1,8 @@
 # PitLane-AI
 
 <div align="center">
-  <img src="https://img.shields.io/pypi/v/pitlane-ai" alt="PyPI version">
-  <img src="https://img.shields.io/pypi/pyversions/pitlane-ai" alt="Python versions">
+  <img src="https://img.shields.io/pypi/v/pitlane-web" alt="PyPI version">
+  <img src="https://img.shields.io/pypi/pyversions/pitlane-web" alt="Python versions">
   <img src="https://img.shields.io/github/license/jshudzina/PitLane-AI" alt="License">
 </div>
 


### PR DESCRIPTION
## Summary
- Converts source code links in architecture docs from relative paths to GitHub URLs
- Fixes RELEASE_PROCESS.md relative path in release-process.md
- Updates PyPI badges to reference `pitlane-web` instead of `pitlane-ai`

## Changes
- **agent-system.md**: Convert F1Agent source link to GitHub URL
- **tool-permissions.md**: Convert tool_permissions.py source link to GitHub URL
- **workspace-management.md**: Convert workspace.py source link to GitHub URL
- **release-process.md**: Fix RELEASE_PROCESS.md relative path from `../../` to `../`
- **index.md**: Update PyPI badges to use `pitlane-web` package name

## Impact
- Resolves all MkDocs build warnings
- Documentation links now work correctly in deployed docs
- Badges accurately reflect separate package publishing strategy

## Test plan
- [x] `uv run mkdocs build` completes with no warnings
- [x] All documentation links are accessible
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)