### PR TITLE
Add weather and race condition tracking to session info

### DIFF
--- a/packages/pitlane-agent/src/pitlane_agent/.claude/skills/f1-analyst/SKILL.md
+++ b/packages/pitlane-agent/src/pitlane_agent/.claude/skills/f1-analyst/SKILL.md
@@ -71,7 +71,28 @@ For any analysis, you may need to fetch session information first:
 pitlane fetch session-info --session-id $PITLANE_SESSION_ID --year 2024 --gp Monaco --session R
 ```
 
-Returns JSON with event name, date, session type, and driver list. Data is saved to workspace.
+Returns JSON with event name, date, session type, driver list, race conditions, and weather data. Data is saved to workspace.
+
+### Included Data
+
+**Basic Info:**
+- Event name, country, session type, session name, date
+- Total laps (if available)
+- Driver list with numbers, abbreviations, names, teams, and positions
+
+**Race Conditions:**
+- `num_safety_cars`: Count of safety car periods
+- `num_virtual_safety_cars`: Count of VSC deployments
+- `num_red_flags`: Count of red flag stoppages
+
+**Weather Data** (min/max/avg statistics):
+- `air_temp`: Air temperature (°C)
+- `track_temp`: Track surface temperature (°C)
+- `humidity`: Relative humidity (%)
+- `pressure`: Atmospheric pressure (hPa)
+- `wind_speed`: Wind speed (m/s)
+
+*Note: Race conditions and weather data may be `null` if not available for the session.*
 
 ## Workspace Data Files
 

--- a/packages/pitlane-agent/src/pitlane_agent/utils/__init__.py
+++ b/packages/pitlane-agent/src/pitlane_agent/utils/__init__.py
@@ -1,4 +1,8 @@
-"""Utility modules for PitLane Agent."""
+"""Utility modules for PitLane Agent.
+
+FastF1 constants (track status codes, etc.) are available in:
+    from pitlane_agent.utils.constants import TRACK_STATUS_*
+"""
 
 from pitlane_agent.utils.fastf1_cache import get_fastf1_cache_dir
 from pitlane_agent.utils.filename import sanitize_filename

--- a/packages/pitlane-agent/src/pitlane_agent/utils/constants.py
+++ b/packages/pitlane-agent/src/pitlane_agent/utils/constants.py
@@ -1,0 +1,15 @@
+"""Constants for FastF1 data processing.
+
+This module contains constant values used across the PitLane Agent,
+particularly for interpreting FastF1 data structures.
+"""
+
+# Track Status Codes
+# Reference: https://docs.fastf1.dev/core.html#fastf1.core.SessionResults.track_status
+TRACK_STATUS_ALL_CLEAR = "1"
+TRACK_STATUS_YELLOW = "2"
+TRACK_STATUS_GREEN = "3"
+TRACK_STATUS_SAFETY_CAR = "4"
+TRACK_STATUS_RED_FLAG = "5"
+TRACK_STATUS_VSC_DEPLOYED = "6"
+TRACK_STATUS_VSC_ENDING = "7"

--- a/packages/pitlane-agent/tests/scripts/test_session_info.py
+++ b/packages/pitlane-agent/tests/scripts/test_session_info.py
@@ -88,17 +88,17 @@ class TestExtractWeatherData:
         result = _extract_weather_data(mock_session)
 
         assert result is not None
-        assert result["air_temp_celsius"]["min"] == 22.5
-        assert result["air_temp_celsius"]["max"] == 24.5
-        assert result["air_temp_celsius"]["avg"] == 23.38
-        assert result["track_temp_celsius"]["min"] == 35.0
-        assert result["track_temp_celsius"]["max"] == 38.0
+        assert result["air_temp"]["min"] == 22.5
+        assert result["air_temp"]["max"] == 24.5
+        assert result["air_temp"]["avg"] == 23.38
+        assert result["track_temp"]["min"] == 35.0
+        assert result["track_temp"]["max"] == 38.0
         assert result["humidity"]["min"] == 45.0
         assert result["humidity"]["max"] == 48.0
         assert result["pressure"]["min"] == 1013.25
         assert result["pressure"]["max"] == 1013.50
-        assert result["wind_speed_mps"]["min"] == 2.5
-        assert result["wind_speed_mps"]["max"] == 3.2
+        assert result["wind_speed"]["min"] == 2.5
+        assert result["wind_speed"]["max"] == 3.2
 
     def test_extract_weather_data_with_nan_values(self):
         """Test extracting weather data with NaN values."""
@@ -117,8 +117,8 @@ class TestExtractWeatherData:
         result = _extract_weather_data(mock_session)
 
         assert result is not None
-        assert result["air_temp_celsius"]["min"] == 22.5
-        assert result["air_temp_celsius"]["max"] == 24.5
+        assert result["air_temp"]["min"] == 22.5
+        assert result["air_temp"]["max"] == 24.5
         assert result["pressure"]["min"] is None
         assert result["pressure"]["max"] is None
         assert result["pressure"]["avg"] is None
@@ -138,12 +138,12 @@ class TestExtractWeatherData:
         result = _extract_weather_data(mock_session)
 
         assert result is not None
-        assert result["air_temp_celsius"]["min"] == 22.5
-        assert result["track_temp_celsius"]["min"] is None
-        assert result["track_temp_celsius"]["max"] is None
-        assert result["track_temp_celsius"]["avg"] is None
+        assert result["air_temp"]["min"] == 22.5
+        assert result["track_temp"]["min"] is None
+        assert result["track_temp"]["max"] is None
+        assert result["track_temp"]["avg"] is None
         assert result["pressure"]["min"] is None
-        assert result["wind_speed_mps"]["min"] is None
+        assert result["wind_speed"]["min"] is None
 
     def test_extract_weather_data_empty_dataframe(self):
         """Test extracting weather data from empty DataFrame."""
@@ -207,11 +207,11 @@ class TestSessionInfoBusinessLogic:
             "num_red_flags": 0,
         }
         mock_extract_weather_data.return_value = {
-            "air_temp_celsius": {"min": 22.5, "max": 24.5, "avg": 23.5},
-            "track_temp_celsius": {"min": 35.0, "max": 38.0, "avg": 36.5},
+            "air_temp": {"min": 22.5, "max": 24.5, "avg": 23.5},
+            "track_temp": {"min": 35.0, "max": 38.0, "avg": 36.5},
             "humidity": {"min": 45.0, "max": 48.0, "avg": 46.5},
             "pressure": {"min": 1013.25, "max": 1013.50, "avg": 1013.38},
-            "wind_speed_mps": {"min": 2.5, "max": 3.2, "avg": 2.85},
+            "wind_speed": {"min": 2.5, "max": 3.2, "avg": 2.85},
         }
 
         # Call function
@@ -231,7 +231,7 @@ class TestSessionInfoBusinessLogic:
         assert result["race_conditions"] is not None
         assert result["race_conditions"]["num_safety_cars"] == 2
         assert result["weather"] is not None
-        assert result["weather"]["air_temp_celsius"]["avg"] == 23.5
+        assert result["weather"]["air_temp"]["avg"] == 23.5
 
         # Verify FastF1 was called correctly
         mock_fastf1.get_session.assert_called_once_with(2024, "Monaco", "Q")


### PR DESCRIPTION
## Summary
- Adds weather data extraction (air/track temperature, humidity, pressure, wind speed with min/max/avg statistics)
- Adds race condition tracking (safety cars, virtual safety cars, red flags)
- Removes CLI interface in favor of library-only function
- Adds comprehensive unit tests for new extraction functions

## Changes
### New Features
- `_extract_track_status()`: Extracts counts of safety cars, VSC, and red flags from session track status data
- `_extract_weather_data()`: Extracts weather statistics (min/max/avg) for air temp, track temp, humidity, pressure, and wind speed
- Enhanced `get_session_info()` to return race conditions and weather data
- Graceful handling of missing data (returns `None` when data is unavailable)

### Refactoring
- Removed Click-based CLI interface (`cli()` function)
- Added TypedDict definitions for better type safety (`RaceConditions`, `WeatherStats`, `WeatherData`)
- Improved error handling with `contextlib.suppress` for `DataNotLoadedError`

### Testing
- Added unit tests for `_extract_track_status()` covering valid data, no incidents, missing data, and multiple incidents
- Added unit tests for `_extract_weather_data()` covering complete data, NaN values, missing columns, empty DataFrame, and missing data
- Updated integration tests for `get_session_info()` to verify race conditions and weather are included

## Test plan
- [x] Run existing tests: `uv run pytest packages/pitlane-agent/tests/scripts/test_session_info.py`
- [x] Verify all pre-commit hooks pass
- [x] Test with real F1 session data to ensure weather and race conditions are extracted correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)