### PR TITLE
feat: implement standings data fetching commands (#61)

### DIFF
--- a/packages/pitlane-agent/src/pitlane_agent/scripts/constructor_standings.py
+++ b/packages/pitlane-agent/src/pitlane_agent/scripts/constructor_standings.py
@@ -7,6 +7,10 @@ Usage:
 
 import fastf1.ergast as ergast
 
+# Constants
+MIN_F1_YEAR = 1950
+FINAL_ROUND = "last"
+
 
 def get_constructor_standings(
     year: int,
@@ -32,8 +36,8 @@ def get_constructor_standings(
     ergast_api = ergast.Ergast()
 
     # Fetch constructor standings
-    # Use 'last' for final standings if round_number not specified
-    round_param = round_number if round_number is not None else "last"
+    # Use FINAL_ROUND for final standings if round_number not specified
+    round_param = round_number if round_number is not None else FINAL_ROUND
     response = ergast_api.get_constructor_standings(season=year, round=round_param)
 
     # Extract round information from response description

--- a/packages/pitlane-agent/src/pitlane_agent/scripts/driver_standings.py
+++ b/packages/pitlane-agent/src/pitlane_agent/scripts/driver_standings.py
@@ -8,6 +8,10 @@ Usage:
 import fastf1.ergast as ergast
 import pandas as pd
 
+# Constants
+MIN_F1_YEAR = 1950
+FINAL_ROUND = "last"
+
 
 def get_driver_standings(
     year: int,
@@ -33,8 +37,8 @@ def get_driver_standings(
     ergast_api = ergast.Ergast()
 
     # Fetch driver standings
-    # Use 'last' for final standings if round_number not specified
-    round_param = round_number if round_number is not None else "last"
+    # Use FINAL_ROUND for final standings if round_number not specified
+    round_param = round_number if round_number is not None else FINAL_ROUND
     response = ergast_api.get_driver_standings(season=year, round=round_param)
 
     # Extract round information from response description
@@ -51,7 +55,7 @@ def get_driver_standings(
             # Handle date of birth - convert Timestamp to string
             date_of_birth = row.get("dateOfBirth")
             if pd.isna(date_of_birth):
-                date_of_birth = "Unknown"
+                date_of_birth = None
             elif isinstance(date_of_birth, pd.Timestamp):
                 date_of_birth = date_of_birth.strftime("%Y-%m-%d")
 

--- a/packages/pitlane-agent/tests/scripts/test_constructor_standings.py
+++ b/packages/pitlane-agent/tests/scripts/test_constructor_standings.py
@@ -168,10 +168,19 @@ class TestConstructorStandingsCLI:
         """Test successful CLI execution."""
         # Mock workspace functions
         mock_exists.return_value = True
+
+        # Create mock file that doesn't exist yet
+        mock_file = Mock()
+        mock_file.exists.return_value = False
+        mock_file.__str__ = lambda self: "/tmp/test/data/constructor_standings.json"
+
+        # Create mock data dir
+        mock_data_dir = Mock()
+        mock_data_dir.__truediv__ = lambda self, x: mock_file
+
+        # Create mock workspace path
         mock_path = Mock()
-        mock_path.__truediv__ = lambda self, x: Mock(
-            __truediv__=lambda s, y: "/tmp/test/data/constructor_standings.json"
-        )
+        mock_path.__truediv__ = lambda self, x: mock_data_dir
         mock_get_path.return_value = mock_path
 
         # Mock standings data
@@ -203,10 +212,19 @@ class TestConstructorStandingsCLI:
     def test_cli_with_round_filter(self, mock_get_standings, mock_get_path, mock_exists):
         """Test CLI with round filter."""
         mock_exists.return_value = True
+
+        # Create mock file that doesn't exist yet
+        mock_file = Mock()
+        mock_file.exists.return_value = False
+        mock_file.__str__ = lambda self: "/tmp/test/data/constructor_standings.json"
+
+        # Create mock data dir
+        mock_data_dir = Mock()
+        mock_data_dir.__truediv__ = lambda self, x: mock_file
+
+        # Create mock workspace path
         mock_path = Mock()
-        mock_path.__truediv__ = lambda self, x: Mock(
-            __truediv__=lambda s, y: "/tmp/test/data/constructor_standings.json"
-        )
+        mock_path.__truediv__ = lambda self, x: mock_data_dir
         mock_get_path.return_value = mock_path
 
         mock_get_standings.return_value = {

--- a/packages/pitlane-agent/tests/scripts/test_driver_standings.py
+++ b/packages/pitlane-agent/tests/scripts/test_driver_standings.py
@@ -187,8 +187,19 @@ class TestDriverStandingsCLI:
         """Test successful CLI execution."""
         # Mock workspace functions
         mock_exists.return_value = True
+
+        # Create mock file that doesn't exist yet
+        mock_file = Mock()
+        mock_file.exists.return_value = False
+        mock_file.__str__ = lambda self: "/tmp/test/data/driver_standings.json"
+
+        # Create mock data dir
+        mock_data_dir = Mock()
+        mock_data_dir.__truediv__ = lambda self, x: mock_file
+
+        # Create mock workspace path
         mock_path = Mock()
-        mock_path.__truediv__ = lambda self, x: Mock(__truediv__=lambda s, y: "/tmp/test/data/driver_standings.json")
+        mock_path.__truediv__ = lambda self, x: mock_data_dir
         mock_get_path.return_value = mock_path
 
         # Mock standings data
@@ -220,8 +231,19 @@ class TestDriverStandingsCLI:
     def test_cli_with_round_filter(self, mock_get_standings, mock_get_path, mock_exists):
         """Test CLI with round filter."""
         mock_exists.return_value = True
+
+        # Create mock file that doesn't exist yet
+        mock_file = Mock()
+        mock_file.exists.return_value = False
+        mock_file.__str__ = lambda self: "/tmp/test/data/driver_standings.json"
+
+        # Create mock data dir
+        mock_data_dir = Mock()
+        mock_data_dir.__truediv__ = lambda self, x: mock_file
+
+        # Create mock workspace path
         mock_path = Mock()
-        mock_path.__truediv__ = lambda self, x: Mock(__truediv__=lambda s, y: "/tmp/test/data/driver_standings.json")
+        mock_path.__truediv__ = lambda self, x: mock_data_dir
         mock_get_path.return_value = mock_path
 
         mock_get_standings.return_value = {


### PR DESCRIPTION
## Summary

Implement CLI commands to fetch and store driver and constructor championship standings data as a prerequisite for championship possibilities analysis (#50).

## New Commands

```bash
# Fetch driver championship standings
pitlane fetch driver-standings --session-id $SESSION_ID --year 2024
pitlane fetch driver-standings --session-id $SESSION_ID --year 2024 --round 10

# Fetch constructor championship standings  
pitlane fetch constructor-standings --session-id $SESSION_ID --year 2024
pitlane fetch constructor-standings --session-id $SESSION_ID --year 2024 --round 10
```

## Features

- ✅ Fetch standings from Ergast API via FastF1
- ✅ Store data in workspace data directory as JSON
- ✅ Support for current and historical seasons (1950-present)
- ✅ Sprint race points automatically included
- ✅ Historical points systems handled correctly
- ✅ Round filtering for mid-season standings
- ✅ Comprehensive error handling and validation

## Implementation Details

**New Files:**
- `driver_standings.py` - Driver championship standings fetching (92 lines)
- `constructor_standings.py` - Constructor championship standings fetching (69 lines)
- `test_driver_standings.py` - Comprehensive test coverage (303 lines)
- `test_constructor_standings.py` - Comprehensive test coverage (301 lines)

**Modified Files:**
- `cli_fetch.py` - Added two new CLI commands (+112 lines)

**Data Schema:**

Driver standings stored at: `~/.pitlane/workspaces/{session_id}/data/driver_standings.json`
```json
{
  "year": 2024,
  "round": 24,
  "total_standings": 24,
  "filters": {"round": null},
  "standings": [
    {
      "position": 1,
      "points": 437.0,
      "wins": 9,
      "driver_id": "max_verstappen",
      "driver_code": "VER",
      "driver_number": 3,
      "given_name": "Max",
      "family_name": "Verstappen",
      "full_name": "Max Verstappen",
      "nationality": "Dutch",
      "date_of_birth": "1997-09-30",
      "teams": ["Red Bull"],
      "team_ids": ["red_bull"]
    }
  ]
}
```

Constructor standings stored at: `~/.pitlane/workspaces/{session_id}/data/constructor_standings.json`
```json
{
  "year": 2024,
  "round": 24,
  "total_standings": 10,
  "filters": {"round": null},
  "standings": [
    {
      "position": 1,
      "points": 666.0,
      "wins": 6,
      "constructor_id": "mclaren",
      "constructor_name": "McLaren",
      "nationality": "British"
    }
  ]
}
```

## Test Coverage

- **97% total coverage** (exceeds 80% requirement)
  - driver_standings.py: 96% coverage
  - constructor_standings.py: 100% coverage
- **22 tests total** - All passing ✅
  - 11 driver standings tests (business logic + CLI)
  - 11 constructor standings tests (business logic + CLI)

**Test Categories:**
- Business logic tests (successful fetch, filtering, error handling)
- CLI integration tests (validation, error propagation)
- Historical data handling (NaN driver numbers, varying points systems)

## Quality Checks

- ✅ All tests passing (22/22)
- ✅ Code coverage >80% (97%)
- ✅ Passes `ruff check`
- ✅ Passes `ruff format`
- ✅ Pre-commit hooks passing
- ✅ Integration testing completed

## Integration Testing

Successfully tested:
- ✓ 2024 current season standings (final)
- ✓ 2024 mid-season standings (round 10)
- ✓ 2010 historical season (different points system)
- ✓ Error handling (invalid year: 1949)
- ✓ Workspace validation
- ✓ Data structure verification

## Related Issues

Closes #61

Part of #50 - Required as a prerequisite before championship possibilities analysis can be implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)