### PR TITLE
chore: update Python version requirement to 3.12-3.14

### DIFF
--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.12', '3.13']
+        python-version: ['3.12', '3.13', '3.14']
 
     steps:
       - name: Checkout code
@@ -92,14 +92,6 @@ jobs:
           cd packages/pitlane-web
           uv run pytest --cov --cov-report=xml --cov-report=term
           cd ../..
-
-      - name: Upload coverage reports
-        uses: codecov/codecov-action@v5
-        if: matrix.python-version == '3.11'
-        with:
-          file: ./coverage.xml
-          fail_ci_if_error: false
-          token: ${{ secrets.CODECOV_TOKEN }}
 
   build:
     name: Build Packages

--- a/packages/pitlane-agent/pyproject.toml
+++ b/packages/pitlane-agent/pyproject.toml
@@ -3,7 +3,7 @@ name = "pitlane-agent"
 version = "0.1.3"
 description = "AI agent for F1 data analysis using Claude Agent SDK and FastF1"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.12,<3.15"
 license = { text = "Apache-2.0" }
 authors = [
     { name = "John Hudzina" , email="pitlaneagent@gmail.com" },
@@ -13,9 +13,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [

--- a/packages/pitlane-web/pyproject.toml
+++ b/packages/pitlane-web/pyproject.toml
@@ -3,7 +3,7 @@ name = "pitlane-web"
 version = "0.1.3"
 description = "Web interface for PitLane AI"
 readme = "README.md"
-requires-python = ">=3.11,<3.14"
+requires-python = ">=3.12,<3.15"
 license = { text = "Apache-2.0" }
 authors = [
     { name = "John Hudzina" , email="pitlaneagent@gmail.com" },
@@ -13,9 +13,9 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: 3 :: Only",
 ]
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "pitlane-ai"
 version = "0.1.3"
 description = "F1 data analysis powered by AI agents"
 readme = "README.md"
-requires-python = ">=3.12,<3.14"
+requires-python = ">=3.12,<3.15"
 license = { text = "Apache-2.0" }
 authors = [
     { name = "John Hudzina" , email="pitlaneagent@gmail.com" },


### PR DESCRIPTION
## Summary
- Update `requires-python` to `>=3.12,<3.15` across all packages
- Remove Python 3.11 from classifiers
- Add Python 3.14 to classifiers and CI test matrix
- Remove codecov upload step from workflow

## Test plan
- [x] CI tests pass on Python 3.12, 3.13, and 3.14
- [x] Package builds successfully
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)