### PR TITLE
chore: update fastf1 to >=3.8 for 2026 season

### DIFF
--- a/packages/pitlane-agent/pyproject.toml
+++ b/packages/pitlane-agent/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
 dependencies = [
     "claude-agent-sdk",
     "click>=8.1.0",
-    "fastf1>=3.0",
+    "fastf1>=3.8",
     "matplotlib>=3.8",
     "numpy>=1.24",
     "opentelemetry-api>=1.24.0",

--- a/uv.lock
+++ b/uv.lock
@@ -503,7 +503,7 @@ wheels = [
 
 [[package]]
 name = "fastf1"
-version = "3.7.0"
+version = "3.8.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "cryptography" },
@@ -511,6 +511,7 @@ dependencies = [
     { name = "numpy" },
     { name = "pandas" },
     { name = "platformdirs" },
+    { name = "pydantic" },
     { name = "pyjwt" },
     { name = "python-dateutil" },
     { name = "rapidfuzz" },
@@ -521,9 +522,9 @@ dependencies = [
     { name = "timple" },
     { name = "websockets" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f9/65/83a948a8b5f2c2657706756f6e33457cddd08a11b47624af9cff54a9e5a1/fastf1-3.7.0.tar.gz", hash = "sha256:db53efd030cffda109ba357b86e68e56d1eaa975b4dee10560dbee265c55e78e", size = 132980, upload-time = "2025-11-27T21:56:13.112Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/03/74de84691c192eb66531dc1214bd108190dbc168fce98ea0186a1a6ec4b3/fastf1-3.8.1.tar.gz", hash = "sha256:337e787b8cd8b991734fd9ba829e025112f57cfe9fbbd7d332fca04f9f675e0d", size = 135392, upload-time = "2026-02-11T18:33:13.747Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/28/46/d83e255fe78c4a14d7b9fce8fb61b44be66be5be0cb9f37b27f1aeaf68d3/fastf1-3.7.0-py3-none-any.whl", hash = "sha256:ef7acdc7018bcab530d3bd8709c59aca1f9797139eabcc2b2b0f5554ad6ea30a", size = 137991, upload-time = "2025-11-27T21:56:11.629Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/ab/5e2dae97b5f625b8f09837fc31cde5d746293205ab2451b1e2f56e09303d/fastf1-3.8.1-py3-none-any.whl", hash = "sha256:0a8dc7604cd5f8d09ebbb9dee325ac31517ecaaaee84e212e99f08b3243272e7", size = 135467, upload-time = "2026-02-11T18:33:11.499Z" },
 ]
 
 [[package]]
@@ -1464,7 +1465,7 @@ dependencies = [
 requires-dist = [
     { name = "claude-agent-sdk" },
     { name = "click", specifier = ">=8.1.0" },
-    { name = "fastf1", specifier = ">=3.0" },
+    { name = "fastf1", specifier = ">=3.8" },
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "numpy", specifier = ">=1.24" },
     { name = "opentelemetry-api", specifier = ">=1.24.0" },


### PR DESCRIPTION
## Summary
- Bump `fastf1` minimum version from `>=3.0` to `>=3.8` (resolves to 3.8.1)
- Update `uv.lock` with new dependency tree (adds `pydantic` transitive dep)

## Test plan
- [x] Verify `uv sync` resolves correctly
- [x] Run existing tests to confirm no breaking changes with fastf1 3.8.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)