### PR TITLE
fix: resolve fastf1 3.8 deprecation warnings

### DIFF
--- a/packages/pitlane-agent/src/pitlane_agent/commands/analyze/lap_times.py
+++ b/packages/pitlane-agent/src/pitlane_agent/commands/analyze/lap_times.py
@@ -40,7 +40,7 @@ def generate_lap_times_chart(
 
     # Setup plotting
     setup_plot_style()
-    fastf1.plotting.setup_mpl(misc_mpl_mods=False)
+    fastf1.plotting.setup_mpl()
 
     # Create figure
     fig, ax = plt.subplots(figsize=(12, 7))
@@ -50,7 +50,7 @@ def generate_lap_times_chart(
 
     # Plot each driver's lap times
     for driver_abbr in drivers:
-        driver_laps = session.laps.pick_driver(driver_abbr).pick_quicklaps()
+        driver_laps = session.laps.pick_drivers(driver_abbr).pick_quicklaps()
 
         if driver_laps.empty:
             continue

--- a/packages/pitlane-agent/src/pitlane_agent/commands/analyze/lap_times_distribution.py
+++ b/packages/pitlane-agent/src/pitlane_agent/commands/analyze/lap_times_distribution.py
@@ -72,7 +72,7 @@ def generate_lap_times_distribution_chart(
 
     # Setup plotting
     setup_plot_style()
-    fastf1.plotting.setup_mpl(mpl_timedelta_support=True, misc_mpl_mods=False)
+    fastf1.plotting.setup_mpl(mpl_timedelta_support=True)
 
     # Create figure
     fig, ax = plt.subplots(figsize=(12, 7))

--- a/packages/pitlane-agent/src/pitlane_agent/commands/analyze/position_changes.py
+++ b/packages/pitlane-agent/src/pitlane_agent/commands/analyze/position_changes.py
@@ -41,7 +41,7 @@ def _extract_driver_position_data(
     Returns:
         Dictionary with driver statistics, or None if driver should be excluded
     """
-    driver_laps = session.laps.pick_driver(driver_abbr)
+    driver_laps = session.laps.pick_drivers(driver_abbr)
 
     if driver_laps.empty:
         return None
@@ -219,7 +219,7 @@ def generate_position_changes_chart(
 
     # Setup plotting
     setup_plot_style()
-    fastf1.plotting.setup_mpl(misc_mpl_mods=False)
+    fastf1.plotting.setup_mpl()
 
     # Create figure
     fig, ax = plt.subplots(figsize=(FIGURE_WIDTH, FIGURE_HEIGHT))

--- a/packages/pitlane-agent/src/pitlane_agent/commands/analyze/speed_trace.py
+++ b/packages/pitlane-agent/src/pitlane_agent/commands/analyze/speed_trace.py
@@ -55,7 +55,7 @@ def generate_speed_trace_chart(
 
     # Setup plotting
     setup_plot_style()
-    fastf1.plotting.setup_mpl(misc_mpl_mods=False)
+    fastf1.plotting.setup_mpl()
 
     # Create figure with wide format for full lap distance
     fig, ax = plt.subplots(figsize=(14, 7))
@@ -67,7 +67,7 @@ def generate_speed_trace_chart(
     # Plot each driver's speed trace
     for driver_abbr in drivers:
         # Get fastest lap for the driver
-        driver_laps = session.laps.pick_driver(driver_abbr)
+        driver_laps = session.laps.pick_drivers(driver_abbr)
 
         if driver_laps.empty:
             continue

--- a/packages/pitlane-agent/src/pitlane_agent/commands/analyze/tyre_strategy.py
+++ b/packages/pitlane-agent/src/pitlane_agent/commands/analyze/tyre_strategy.py
@@ -50,7 +50,7 @@ def generate_tyre_strategy_chart(
     strategies = []
 
     for idx, driver in enumerate(drivers):
-        driver_laps = session.laps.pick_driver(driver)
+        driver_laps = session.laps.pick_drivers(driver)
 
         if driver_laps.empty:
             continue

--- a/packages/pitlane-agent/src/pitlane_agent/commands/fetch/session_info.py
+++ b/packages/pitlane-agent/src/pitlane_agent/commands/fetch/session_info.py
@@ -11,7 +11,8 @@ import contextlib
 from typing import TypedDict
 
 import pandas as pd
-from fastf1.core import DataNotLoadedError, Session
+from fastf1.core import Session
+from fastf1.exceptions import DataNotLoadedError
 
 from pitlane_agent.utils.constants import (
     TRACK_STATUS_RED_FLAG,

--- a/packages/pitlane-agent/tests/commands/test_lap_times.py
+++ b/packages/pitlane-agent/tests/commands/test_lap_times.py
@@ -37,7 +37,7 @@ class TestLapTimesBusinessLogic:
                 {"LapNumber": 2, "LapTime": pd.Timedelta(seconds=89)},
             ]
         )
-        mock_fastf1_session.laps.pick_driver.return_value.pick_quicklaps.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value.pick_quicklaps.return_value = mock_laps
 
         # Mock pyplot
         mock_fig = MagicMock()
@@ -103,7 +103,7 @@ class TestLapTimesBusinessLogic:
                 {"LapNumber": 2, "LapTime": pd.Timedelta(seconds=89)},
             ]
         )
-        mock_fastf1_session.laps.pick_driver.return_value.pick_quicklaps.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value.pick_quicklaps.return_value = mock_laps
 
         # Mock pyplot
         mock_fig = MagicMock()

--- a/packages/pitlane-agent/tests/commands/test_position_changes.py
+++ b/packages/pitlane-agent/tests/commands/test_position_changes.py
@@ -51,12 +51,12 @@ class TestPositionChangesBusinessLogic:
             ]
         )
 
-        def mock_pick_driver(driver):
+        def mock_pick_drivers(driver):
             if driver == "VER":
                 return mock_laps_ver
             return mock_laps_ham
 
-        mock_fastf1_session.laps.pick_driver.side_effect = mock_pick_driver
+        mock_fastf1_session.laps.pick_drivers.side_effect = mock_pick_drivers
 
         # Mock pyplot
         mock_fig = MagicMock()
@@ -104,7 +104,7 @@ class TestPositionChangesBusinessLogic:
                 {"LapNumber": 2, "Position": 1, "PitOutTime": pd.NaT},
             ]
         )
-        mock_fastf1_session.laps.pick_driver.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_laps
 
         mock_fig = MagicMock()
         mock_ax = MagicMock()
@@ -147,7 +147,7 @@ class TestPositionChangesBusinessLogic:
                 {"LapNumber": 1, "Position": 1, "PitOutTime": pd.NaT},
             ]
         )
-        mock_fastf1_session.laps.pick_driver.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_laps
 
         mock_fig = MagicMock()
         mock_ax = MagicMock()
@@ -187,7 +187,7 @@ class TestPositionChangesBusinessLogic:
                 {"LapNumber": 3, "Position": 4, "PitOutTime": pd.NaT},
             ]
         )
-        mock_fastf1_session.laps.pick_driver.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_laps
 
         mock_fig = MagicMock()
         mock_ax = MagicMock()
@@ -224,7 +224,7 @@ class TestPositionChangesBusinessLogic:
 
         # Mock empty laps (DNS scenario)
         mock_laps = pd.DataFrame()
-        mock_fastf1_session.laps.pick_driver.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_laps
 
         # Mock pyplot
         mock_fig = MagicMock()
@@ -283,7 +283,7 @@ class TestPositionChangesBusinessLogic:
                 {"LapNumber": 4, "Position": 2, "PitOutTime": pd.NaT},  # +2 positions
             ]
         )
-        mock_fastf1_session.laps.pick_driver.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_laps
 
         mock_fig = MagicMock()
         mock_ax = MagicMock()
@@ -326,7 +326,7 @@ class TestPositionChangesBusinessLogic:
                 {"LapNumber": 2, "Position": 1, "PitOutTime": pd.NaT},
             ]
         )
-        mock_fastf1_session.laps.pick_driver.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_laps
 
         mock_fig = MagicMock()
         mock_ax = MagicMock()

--- a/packages/pitlane-agent/tests/commands/test_session_info.py
+++ b/packages/pitlane-agent/tests/commands/test_session_info.py
@@ -4,7 +4,7 @@ from unittest.mock import MagicMock, patch
 
 import pandas as pd
 import pytest
-from fastf1.core import DataNotLoadedError
+from fastf1.exceptions import DataNotLoadedError
 from pitlane_agent.commands.fetch.session_info import (
     _extract_track_status,
     _extract_weather_data,

--- a/packages/pitlane-agent/tests/commands/test_speed_trace.py
+++ b/packages/pitlane-agent/tests/commands/test_speed_trace.py
@@ -53,7 +53,7 @@ class TestSpeedTraceBusinessLogic:
         mock_driver_laps.empty = False
         mock_driver_laps.pick_fastest.return_value = mock_fastest_lap
 
-        mock_fastf1_session.laps.pick_driver.return_value = mock_driver_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_driver_laps
 
         # Mock pyplot
         mock_fig = MagicMock()
@@ -123,7 +123,7 @@ class TestSpeedTraceBusinessLogic:
         mock_driver_laps.empty = False
         mock_driver_laps.pick_fastest.return_value = mock_fastest_lap
 
-        mock_fastf1_session.laps.pick_driver.return_value = mock_driver_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_driver_laps
 
         # Mock pyplot
         mock_fig = MagicMock()
@@ -180,7 +180,7 @@ class TestSpeedTraceBusinessLogic:
         mock_driver_laps.empty = False
         mock_driver_laps.pick_fastest.return_value = mock_fastest_lap
 
-        mock_fastf1_session.laps.pick_driver.return_value = mock_driver_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_driver_laps
 
         # Mock pyplot
         mock_fig = MagicMock()
@@ -261,7 +261,7 @@ class TestSpeedTraceBusinessLogic:
         mock_driver_laps.empty = False
         mock_driver_laps.pick_fastest.return_value = mock_fastest_lap
 
-        mock_fastf1_session.laps.pick_driver.return_value = mock_driver_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_driver_laps
 
         # Mock pyplot
         mock_fig = MagicMock()
@@ -362,10 +362,10 @@ class TestSpeedTraceBusinessLogic:
         mock_valid_laps.pick_fastest.return_value = mock_fastest_lap
 
         # Return different mock based on driver
-        def pick_driver_side_effect(driver):
+        def pick_drivers_side_effect(driver):
             return mock_empty_laps if driver == "VER" else mock_valid_laps
 
-        mock_fastf1_session.laps.pick_driver.side_effect = pick_driver_side_effect
+        mock_fastf1_session.laps.pick_drivers.side_effect = pick_drivers_side_effect
 
         # Mock pyplot
         mock_fig = MagicMock()

--- a/packages/pitlane-agent/tests/commands/test_tyre_strategy.py
+++ b/packages/pitlane-agent/tests/commands/test_tyre_strategy.py
@@ -41,7 +41,7 @@ class TestTyreStrategyBusinessLogic:
                 {"LapNumber": 3, "Compound": "MEDIUM"},
             ]
         )
-        mock_fastf1_session.laps.pick_driver.return_value = mock_laps
+        mock_fastf1_session.laps.pick_drivers.return_value = mock_laps
 
         # Mock pyplot
         mock_fig = MagicMock()


### PR DESCRIPTION
## Summary
- Import `DataNotLoadedError` from `fastf1.exceptions` instead of deprecated `fastf1.core` path
- Replace deprecated `pick_driver()` calls with `pick_drivers()` across all analyze commands
- Remove deprecated `misc_mpl_mods` argument from `setup_mpl()` calls

Closes #84

## Test plan
- [x] All 503 tests pass (324 agent + 179 web)
- [x] Affected 51 tests pass with `DeprecationWarning` promoted to errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)