### PR TITLE
feat(elo): hyperparameter calibration pipeline

### DIFF
--- a/packages/pitlane-elo/pyproject.toml
+++ b/packages/pitlane-elo/pyproject.toml
@@ -60,3 +60,9 @@ addopts = [
 markers = [
     "slow: marks tests as slow running",
 ]
+
+[dependency-groups]
+dev = [
+    "py-spy>=0.4.1",
+    "pyinstrument>=5.1.2",
+]

--- a/packages/pitlane-elo/src/pitlane_elo/__init__.py
+++ b/packages/pitlane-elo/src/pitlane_elo/__init__.py
@@ -1,1 +1,8 @@
 """ELO rating models and story detection for F1."""
+
+import os
+
+# workqueue is Numba's most portable threading backend and avoids TBB/OpenMP
+# deadlocks on machines where the default backend conflicts with the environment.
+# Must be set before numba is imported anywhere in the package.
+os.environ.setdefault("NUMBA_THREADING_LAYER", "workqueue")

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -191,6 +191,11 @@ def calibrate(
     # fatol=0.1: loose LL tolerance is fine here — we're refining a warm-start, not searching from scratch
     res = minimize(neg_ll, x0, method="Nelder-Mead", options={"maxiter": 300, "xatol": 1e-4, "fatol": 0.1})
     k_max, phi_race, phi_season = res.x
+    # Clip back to BOUNDS: Nelder-Mead uses a wider penalty region to avoid
+    # hard-clipping the simplex, but the stored result must satisfy the bounds.
+    k_max = float(np.clip(k_max, *BOUNDS["k_max"]))
+    phi_race = float(np.clip(phi_race, *BOUNDS["phi_race"]))
+    phi_season = float(np.clip(phi_season, *BOUNDS["phi_season"]))
 
     best_config = dataclasses.replace(
         base_config,

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -19,7 +19,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Type
+from typing import Callable, Type
 
 import numpy as np
 from scipy.optimize import minimize
@@ -81,11 +81,16 @@ def random_search(
     *,
     n_trials: int = 100,
     seed: int | None = None,
+    on_trial: Callable[[int, int, float], None] | None = None,
 ) -> list[dict]:
     """Random search over (k_max, phi_race, phi_season).
 
     k_max is sampled log-uniformly (spans an order of magnitude).
     phi values are sampled uniformly over their bounded ranges.
+
+    Args:
+        on_trial: Optional callback called after each trial with
+            (trial_number, n_trials, log_likelihood).
 
     Returns:
         List of dicts with keys k_max, phi_race, phi_season, log_likelihood,
@@ -93,7 +98,7 @@ def random_search(
     """
     rng = np.random.default_rng(seed)
     results = []
-    for _ in range(n_trials):
+    for i in range(n_trials):
         k_max = float(np.exp(rng.uniform(np.log(BOUNDS["k_max"][0]), np.log(BOUNDS["k_max"][1]))))
         phi_race = float(rng.uniform(*BOUNDS["phi_race"]))
         phi_season = float(rng.uniform(*BOUNDS["phi_season"]))
@@ -106,6 +111,8 @@ def random_search(
             cal_end=cal_end,
         )
         results.append({"k_max": k_max, "phi_race": phi_race, "phi_season": phi_season, "log_likelihood": ll})
+        if on_trial is not None:
+            on_trial(i + 1, n_trials, ll)
     return sorted(results, key=lambda r: r["log_likelihood"], reverse=True)
 
 
@@ -120,6 +127,7 @@ def calibrate(
     *,
     n_trials: int = 100,
     seed: int | None = None,
+    on_trial: Callable[[int, int, float], None] | None = None,
 ) -> CalibrationResult:
     """Random search + Nelder-Mead refinement, then score on validation window.
 
@@ -143,6 +151,7 @@ def calibrate(
         warmup_start, cal_start, cal_end,
         n_trials=n_trials,
         seed=seed,
+        on_trial=on_trial,
     )
     best = rand_results[0]
 

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -58,6 +58,7 @@ def _score(
     warmup_start: int,
     cal_start: int,
     cal_end: int,
+    predict_cap: int | None = None,
 ) -> float:
     """Return calibration-window log-likelihood for a given parameter set."""
     config = dataclasses.replace(
@@ -68,7 +69,7 @@ def _score(
         phi_season=float(phi_season),
     )
     model = model_class(config)
-    preds = run_historical(model, warmup_start, cal_end)
+    preds = run_historical(model, warmup_start, cal_end, predict_cap=predict_cap)
     return evaluate_model(preds, cal_start, cal_end)["log_likelihood"]
 
 
@@ -81,6 +82,7 @@ def random_search(
     *,
     n_trials: int = 100,
     seed: int | None = None,
+    predict_cap: int | None = None,
     on_trial: Callable[[int, int, float], None] | None = None,
 ) -> list[dict]:
     """Random search over (k_max, phi_race, phi_season).
@@ -111,6 +113,7 @@ def random_search(
             warmup_start=warmup_start,
             cal_start=cal_start,
             cal_end=cal_end,
+            predict_cap=predict_cap,
         )
         results.append({"k_max": k_max, "phi_race": phi_race, "phi_season": phi_season, "log_likelihood": ll})
         if on_trial is not None:
@@ -129,6 +132,7 @@ def calibrate(
     *,
     n_trials: int = 100,
     seed: int | None = None,
+    predict_cap: int | None = None,
     on_trial: Callable[[int, int, float], None] | None = None,
 ) -> CalibrationResult:
     """Random search + Nelder-Mead refinement, then score on validation window.
@@ -143,6 +147,9 @@ def calibrate(
         val_end: Last year of validation window.
         n_trials: Number of random-search evaluations.
         seed: RNG seed for reproducibility.
+        predict_cap: Cap win-probability predictions to top-N drivers by
+            rating. Substantially reduces per-trial cost with minimal
+            impact on relative log-likelihood rankings.
 
     Returns:
         CalibrationResult with best_config, calibration LL, validation LL,
@@ -156,6 +163,7 @@ def calibrate(
         cal_end,
         n_trials=n_trials,
         seed=seed,
+        predict_cap=predict_cap,
         on_trial=on_trial,
     )
     best = rand_results[0]
@@ -174,6 +182,7 @@ def calibrate(
             warmup_start=warmup_start,
             cal_start=cal_start,
             cal_end=cal_end,
+            predict_cap=predict_cap,
         )
 
     x0 = [best["k_max"], best["phi_race"], best["phi_season"]]

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -93,8 +93,6 @@ def random_search(
     Args:
         on_trial: Optional callback called after each random-search trial with
             (trial_number, n_trials, log_likelihood).
-        on_nm_iter: Optional callback called after each Nelder-Mead iteration
-            with (iteration, log_likelihood).
 
     Returns:
         List of dicts with keys k_max, phi_race, phi_season, log_likelihood,

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -18,8 +18,8 @@ References:
 from __future__ import annotations
 
 import dataclasses
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable, Type
 
 import numpy as np
 from scipy.optimize import minimize
@@ -30,9 +30,9 @@ from pitlane_elo.ratings.base import RatingModel
 
 # Default search bounds
 BOUNDS: dict[str, tuple[float, float]] = {
-    "k_max": (0.05, 1.5),       # log-uniform; asymptotic variance / new-entrant k
+    "k_max": (0.05, 1.5),  # log-uniform; asymptotic variance / new-entrant k
     "phi_race": (0.90, 0.999),  # within-season AR(1) decay, per race
-    "phi_season": (0.60, 0.99), # between-season decay, per year boundary
+    "phi_season": (0.60, 0.99),  # between-season decay, per year boundary
 }
 
 
@@ -41,8 +41,8 @@ class CalibrationResult:
     """Output of a calibration run."""
 
     best_config: EloConfig
-    cal_log_likelihood: float   # on calibration window
-    val_log_likelihood: float   # on validation window
+    cal_log_likelihood: float  # on calibration window
+    val_log_likelihood: float  # on validation window
     n_cal_races: int
     n_val_races: int
     random_results: list[dict]  # all random-search trials, sorted by log_likelihood desc
@@ -53,7 +53,7 @@ def _score(
     phi_race: float,
     phi_season: float,
     *,
-    model_class: Type[RatingModel],
+    model_class: type[RatingModel],
     base_config: EloConfig,
     warmup_start: int,
     cal_start: int,
@@ -73,7 +73,7 @@ def _score(
 
 
 def random_search(
-    model_class: Type[RatingModel],
+    model_class: type[RatingModel],
     base_config: EloConfig,
     warmup_start: int,
     cal_start: int,
@@ -103,7 +103,9 @@ def random_search(
         phi_race = float(rng.uniform(*BOUNDS["phi_race"]))
         phi_season = float(rng.uniform(*BOUNDS["phi_season"]))
         ll = _score(
-            k_max, phi_race, phi_season,
+            k_max,
+            phi_race,
+            phi_season,
             model_class=model_class,
             base_config=base_config,
             warmup_start=warmup_start,
@@ -117,7 +119,7 @@ def random_search(
 
 
 def calibrate(
-    model_class: Type[RatingModel],
+    model_class: type[RatingModel],
     base_config: EloConfig,
     warmup_start: int,
     cal_start: int,
@@ -147,8 +149,11 @@ def calibrate(
         race counts, and the full sorted random-search trial list.
     """
     rand_results = random_search(
-        model_class, base_config,
-        warmup_start, cal_start, cal_end,
+        model_class,
+        base_config,
+        warmup_start,
+        cal_start,
+        cal_end,
         n_trials=n_trials,
         seed=seed,
         on_trial=on_trial,
@@ -161,7 +166,9 @@ def calibrate(
         if not (0.01 <= k_max <= 2.0 and 0.5 <= phi_race < 1.0 and 0.5 <= phi_season < 1.0):
             return 1e9
         return -_score(
-            k_max, phi_race, phi_season,
+            k_max,
+            phi_race,
+            phi_season,
             model_class=model_class,
             base_config=base_config,
             warmup_start=warmup_start,

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -91,8 +91,10 @@ def random_search(
     phi values are sampled uniformly over their bounded ranges.
 
     Args:
-        on_trial: Optional callback called after each trial with
+        on_trial: Optional callback called after each random-search trial with
             (trial_number, n_trials, log_likelihood).
+        on_nm_iter: Optional callback called after each Nelder-Mead iteration
+            with (iteration, log_likelihood).
 
     Returns:
         List of dicts with keys k_max, phi_race, phi_season, log_likelihood,
@@ -134,6 +136,7 @@ def calibrate(
     seed: int | None = None,
     predict_cap: int | None = None,
     on_trial: Callable[[int, int, float], None] | None = None,
+    on_nm_iter: Callable[[int, float], None] | None = None,
 ) -> CalibrationResult:
     """Random search + Nelder-Mead refinement, then score on validation window.
 
@@ -168,6 +171,8 @@ def calibrate(
     )
     best = rand_results[0]
 
+    last_neg_ll: list[float] = [0.0]  # mutable cell so the callback can read the last evaluated LL
+
     def neg_ll(x: list[float]) -> float:
         k_max, phi_race, phi_season = x
         # Penalty for out-of-bounds (Nelder-Mead doesn't respect constraints).
@@ -175,7 +180,7 @@ def calibrate(
         # from a warm-start near a boundary without being hard-clipped.
         if not (0.01 <= k_max <= 2.0 and 0.5 <= phi_race < 1.0 and 0.5 <= phi_season < 1.0):
             return 1e9
-        return -_score(
+        result = -_score(
             k_max,
             phi_race,
             phi_season,
@@ -186,10 +191,25 @@ def calibrate(
             cal_end=cal_end,
             predict_cap=predict_cap,
         )
+        last_neg_ll[0] = result
+        return result
+
+    nm_iter: list[int] = [0]
+
+    def _nm_callback(_: object) -> None:
+        if on_nm_iter is not None:
+            nm_iter[0] += 1
+            on_nm_iter(nm_iter[0], -last_neg_ll[0])
 
     x0 = [best["k_max"], best["phi_race"], best["phi_season"]]
     # fatol=0.1: loose LL tolerance is fine here — we're refining a warm-start, not searching from scratch
-    res = minimize(neg_ll, x0, method="Nelder-Mead", options={"maxiter": 300, "xatol": 1e-4, "fatol": 0.1})
+    res = minimize(
+        neg_ll,
+        x0,
+        method="Nelder-Mead",
+        callback=_nm_callback,
+        options={"maxiter": 300, "xatol": 1e-4, "fatol": 0.1},
+    )
     k_max, phi_race, phi_season = res.x
     # Clip back to BOUNDS: Nelder-Mead uses a wider penalty region to avoid
     # hard-clipping the simplex, but the stored result must satisfy the bounds.

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -170,7 +170,9 @@ def calibrate(
 
     def neg_ll(x: list[float]) -> float:
         k_max, phi_race, phi_season = x
-        # Penalty for out-of-bounds (Nelder-Mead doesn't respect constraints)
+        # Penalty for out-of-bounds (Nelder-Mead doesn't respect constraints).
+        # Wider than BOUNDS intentionally: allows simplex to step beyond random-search region
+        # from a warm-start near a boundary without being hard-clipped.
         if not (0.01 <= k_max <= 2.0 and 0.5 <= phi_race < 1.0 and 0.5 <= phi_season < 1.0):
             return 1e9
         return -_score(
@@ -186,6 +188,7 @@ def calibrate(
         )
 
     x0 = [best["k_max"], best["phi_race"], best["phi_season"]]
+    # fatol=0.1: loose LL tolerance is fine here — we're refining a warm-start, not searching from scratch
     res = minimize(neg_ll, x0, method="Nelder-Mead", options={"maxiter": 300, "xatol": 1e-4, "fatol": 0.1})
     k_max, phi_race, phi_season = res.x
 

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -227,7 +227,7 @@ def calibrate(
 
     # Single run covers both calibration and validation windows
     model = model_class(best_config)
-    preds = run_historical(model, warmup_start, val_end)
+    preds = run_historical(model, warmup_start, val_end, predict_cap=predict_cap)
     cal_metrics = evaluate_model(preds, cal_start, cal_end)
     val_metrics = evaluate_model(preds, val_start, val_end)
 

--- a/packages/pitlane-elo/src/pitlane_elo/calibration.py
+++ b/packages/pitlane-elo/src/pitlane_elo/calibration.py
@@ -1,0 +1,188 @@
+"""Hyperparameter calibration for ELO rating models.
+
+Implements a two-phase search strategy:
+  1. Random search over (k_max, phi_race, phi_season) to find a good region.
+  2. Nelder-Mead local refinement from the best random-search point.
+
+Temporal split design (anchored to regulation-change years):
+  - Warmup  1970–1979: burn ratings in from zero; predictions not scored
+  - Calibration 1980–2013: log-likelihood maximized to select params
+  - Validation  2014–2021: generalization across 2014 hybrid era
+  - Holdout     2022–2025: truly unseen; reported only after param selection
+
+References:
+  Powell (2023) Section 3.4 — specifying hyperparameters
+  Bergstra & Bengio (2012) — random search beats grid search
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Type
+
+import numpy as np
+from scipy.optimize import minimize
+
+from pitlane_elo.config import EloConfig
+from pitlane_elo.prediction.forecast import evaluate_model, run_historical
+from pitlane_elo.ratings.base import RatingModel
+
+# Default search bounds
+BOUNDS: dict[str, tuple[float, float]] = {
+    "k_max": (0.05, 1.5),       # log-uniform; asymptotic variance / new-entrant k
+    "phi_race": (0.90, 0.999),  # within-season AR(1) decay, per race
+    "phi_season": (0.60, 0.99), # between-season decay, per year boundary
+}
+
+
+@dataclass
+class CalibrationResult:
+    """Output of a calibration run."""
+
+    best_config: EloConfig
+    cal_log_likelihood: float   # on calibration window
+    val_log_likelihood: float   # on validation window
+    n_cal_races: int
+    n_val_races: int
+    random_results: list[dict]  # all random-search trials, sorted by log_likelihood desc
+
+
+def _score(
+    k_max: float,
+    phi_race: float,
+    phi_season: float,
+    *,
+    model_class: Type[RatingModel],
+    base_config: EloConfig,
+    warmup_start: int,
+    cal_start: int,
+    cal_end: int,
+) -> float:
+    """Return calibration-window log-likelihood for a given parameter set."""
+    config = dataclasses.replace(
+        base_config,
+        name="calibrating",
+        k_max=float(k_max),
+        phi_race=float(phi_race),
+        phi_season=float(phi_season),
+    )
+    model = model_class(config)
+    preds = run_historical(model, warmup_start, cal_end)
+    return evaluate_model(preds, cal_start, cal_end)["log_likelihood"]
+
+
+def random_search(
+    model_class: Type[RatingModel],
+    base_config: EloConfig,
+    warmup_start: int,
+    cal_start: int,
+    cal_end: int,
+    *,
+    n_trials: int = 100,
+    seed: int | None = None,
+) -> list[dict]:
+    """Random search over (k_max, phi_race, phi_season).
+
+    k_max is sampled log-uniformly (spans an order of magnitude).
+    phi values are sampled uniformly over their bounded ranges.
+
+    Returns:
+        List of dicts with keys k_max, phi_race, phi_season, log_likelihood,
+        sorted by log_likelihood descending.
+    """
+    rng = np.random.default_rng(seed)
+    results = []
+    for _ in range(n_trials):
+        k_max = float(np.exp(rng.uniform(np.log(BOUNDS["k_max"][0]), np.log(BOUNDS["k_max"][1]))))
+        phi_race = float(rng.uniform(*BOUNDS["phi_race"]))
+        phi_season = float(rng.uniform(*BOUNDS["phi_season"]))
+        ll = _score(
+            k_max, phi_race, phi_season,
+            model_class=model_class,
+            base_config=base_config,
+            warmup_start=warmup_start,
+            cal_start=cal_start,
+            cal_end=cal_end,
+        )
+        results.append({"k_max": k_max, "phi_race": phi_race, "phi_season": phi_season, "log_likelihood": ll})
+    return sorted(results, key=lambda r: r["log_likelihood"], reverse=True)
+
+
+def calibrate(
+    model_class: Type[RatingModel],
+    base_config: EloConfig,
+    warmup_start: int,
+    cal_start: int,
+    cal_end: int,
+    val_start: int,
+    val_end: int,
+    *,
+    n_trials: int = 100,
+    seed: int | None = None,
+) -> CalibrationResult:
+    """Random search + Nelder-Mead refinement, then score on validation window.
+
+    Args:
+        model_class: EndureElo or SpeedElo class (not instance).
+        base_config: Config whose non-calibrated fields are inherited.
+        warmup_start: First year to process (ratings burn-in; not scored).
+        cal_start: First year scored during calibration (param selection).
+        cal_end: Last year scored during calibration.
+        val_start: First year of validation window (generalization check).
+        val_end: Last year of validation window.
+        n_trials: Number of random-search evaluations.
+        seed: RNG seed for reproducibility.
+
+    Returns:
+        CalibrationResult with best_config, calibration LL, validation LL,
+        race counts, and the full sorted random-search trial list.
+    """
+    rand_results = random_search(
+        model_class, base_config,
+        warmup_start, cal_start, cal_end,
+        n_trials=n_trials,
+        seed=seed,
+    )
+    best = rand_results[0]
+
+    def neg_ll(x: list[float]) -> float:
+        k_max, phi_race, phi_season = x
+        # Penalty for out-of-bounds (Nelder-Mead doesn't respect constraints)
+        if not (0.01 <= k_max <= 2.0 and 0.5 <= phi_race < 1.0 and 0.5 <= phi_season < 1.0):
+            return 1e9
+        return -_score(
+            k_max, phi_race, phi_season,
+            model_class=model_class,
+            base_config=base_config,
+            warmup_start=warmup_start,
+            cal_start=cal_start,
+            cal_end=cal_end,
+        )
+
+    x0 = [best["k_max"], best["phi_race"], best["phi_season"]]
+    res = minimize(neg_ll, x0, method="Nelder-Mead", options={"maxiter": 300, "xatol": 1e-4, "fatol": 0.1})
+    k_max, phi_race, phi_season = res.x
+
+    best_config = dataclasses.replace(
+        base_config,
+        name=f"{base_config.name}-calibrated",
+        k_max=float(k_max),
+        phi_race=float(phi_race),
+        phi_season=float(phi_season),
+    )
+
+    # Single run covers both calibration and validation windows
+    model = model_class(best_config)
+    preds = run_historical(model, warmup_start, val_end)
+    cal_metrics = evaluate_model(preds, cal_start, cal_end)
+    val_metrics = evaluate_model(preds, val_start, val_end)
+
+    return CalibrationResult(
+        best_config=best_config,
+        cal_log_likelihood=cal_metrics["log_likelihood"],
+        val_log_likelihood=val_metrics["log_likelihood"],
+        n_cal_races=cal_metrics["n_races"],
+        n_val_races=val_metrics["n_races"],
+        random_results=rand_results,
+    )

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -206,6 +206,13 @@ def calibrate(
             nl=True,
         )
 
+    nm_best_so_far: list[float] = []
+
+    def _on_nm_iter(iteration: int, ll: float) -> None:
+        if not nm_best_so_far or ll > nm_best_so_far[0]:
+            nm_best_so_far[:] = [ll]
+        click.echo(f"  [NM {iteration:>3}] ll={ll:>10.2f}  best={nm_best_so_far[0]:>10.2f}", nl=True)
+
     cap = predict_cap or None
     result = run_calibrate(
         model_class,
@@ -219,8 +226,9 @@ def calibrate(
         seed=seed,
         predict_cap=cap,
         on_trial=_on_trial,
+        on_nm_iter=_on_nm_iter,
     )
-    click.echo("Random search done. Running Nelder-Mead refinement...")
+    click.echo("Nelder-Mead done.")
 
     # Top-N random search results
     click.echo(f"\nTop {min(top_n, len(result.random_results))} random search results:")

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -6,6 +6,8 @@ import logging
 
 import click
 
+from pitlane_elo.calibration import calibrate as run_calibrate
+from pitlane_elo.config import ENDURE_ELO_DEFAULT, SPEED_ELO_DEFAULT
 from pitlane_elo.prediction.forecast import compare_models, evaluate_model, run_historical
 from pitlane_elo.ratings.endure_elo import EndureElo
 from pitlane_elo.ratings.speed_elo import SpeedElo
@@ -128,6 +130,107 @@ def evaluate(
     click.echo(f"{'Race-level % (E > S)':<25} {comparison['race_level_pct']:>12.1%}")
     click.echo(f"{'Log-wealth D(E,S)':<25} {comparison['log_wealth_ratio']:>12.2f}")
     click.echo(f"{'Races compared':<25} {comparison['n_races']:>12}")
+
+
+@main.command()
+@click.option("--warmup-start", type=int, default=1970, help="First season to process (burn-in; not scored).")
+@click.option("--cal-start", type=int, default=1980, help="First year scored during calibration.")
+@click.option("--cal-end", type=int, default=2013, help="Last year scored during calibration.")
+@click.option("--val-start", type=int, default=2014, help="First year of validation window.")
+@click.option("--val-end", type=int, default=2021, help="Last year of validation window.")
+@click.option("--holdout-start", type=int, default=None, help="First holdout year (reported only).")
+@click.option("--holdout-end", type=int, default=None, help="Last year of holdout.")
+@click.option("--model", "model_name", type=click.Choice(["endure-elo", "speed-elo"]), default="endure-elo")
+@click.option("--n-trials", type=int, default=100, help="Number of random-search trials.")
+@click.option("--seed", type=int, default=None, help="RNG seed for reproducibility.")
+@click.option("--top-n", type=int, default=10, help="Show top-N random search results.")
+def calibrate(
+    warmup_start: int,
+    cal_start: int,
+    cal_end: int,
+    val_start: int,
+    val_end: int,
+    holdout_start: int | None,
+    holdout_end: int | None,
+    model_name: str,
+    n_trials: int,
+    seed: int | None,
+    top_n: int,
+) -> None:
+    """Calibrate k_max, phi_race, phi_season via random search + Nelder-Mead.
+
+    \b
+    Phase 1 — Random search (n-trials evaluations):
+      Samples (k_max, phi_race, phi_season) from their bounds and scores each
+      on the calibration window. k_max is sampled log-uniformly.
+    Phase 2 — Nelder-Mead refinement:
+      Local optimizer starts from the best random-search point.
+    Phase 3 — Validation:
+      Best config is scored on val-start to val-end (not used for selection).
+    Phase 4 — Holdout (optional):
+      If --holdout-start/end are given, the final config is scored on that
+      window and reported. This is the truly unseen evaluation.
+
+    \b
+    Default temporal split (anchored to regulation changes):
+      Calibration: 1980–2013  (pre-hybrid era)
+      Validation:  2014–2021  (hybrid era, crosses 2014 regulation change)
+      Holdout:     2022–2025  (ground-effect era)
+    """
+    model_class = EndureElo if model_name == "endure-elo" else SpeedElo
+    base_config = ENDURE_ELO_DEFAULT if model_name == "endure-elo" else SPEED_ELO_DEFAULT
+
+    click.echo(
+        f"Calibrating {model_name}: warmup {warmup_start}, "
+        f"cal {cal_start}–{cal_end}, val {val_start}–{val_end}"
+    )
+    click.echo(f"Running {n_trials} random trials" + (f" (seed={seed})" if seed is not None else "") + "...")
+
+    result = run_calibrate(
+        model_class,
+        base_config,
+        warmup_start,
+        cal_start,
+        cal_end,
+        val_start,
+        val_end,
+        n_trials=n_trials,
+        seed=seed,
+    )
+
+    # Top-N random search results
+    click.echo(f"\nTop {min(top_n, len(result.random_results))} random search results:")
+    click.echo(f"  {'k_max':>8}  {'phi_race':>10}  {'phi_season':>10}  {'cal_ll':>10}")
+    click.echo("  " + "-" * 44)
+    for r in result.random_results[:top_n]:
+        click.echo(
+            f"  {r['k_max']:>8.4f}  {r['phi_race']:>10.4f}  {r['phi_season']:>10.4f}  {r['log_likelihood']:>10.2f}"
+        )
+
+    # Best config after refinement
+    cfg = result.best_config
+    click.echo("\nBest config (after Nelder-Mead refinement):")
+    click.echo(f"  k_max      = {cfg.k_max:.6f}")
+    click.echo(f"  phi_race   = {cfg.phi_race:.6f}")
+    click.echo(f"  phi_season = {cfg.phi_season:.6f}")
+
+    # Calibration / validation summary
+    click.echo(f"\n{'Window':<20} {'Log-likelihood':>15} {'Races':>8}")
+    click.echo("-" * 45)
+    click.echo(f"{'Calibration':<20} {result.cal_log_likelihood:>15.2f} {result.n_cal_races:>8}")
+    click.echo(f"{'Validation':<20} {result.val_log_likelihood:>15.2f} {result.n_val_races:>8}")
+
+    # Optional holdout
+    if holdout_start is not None and holdout_end is not None:
+        from pitlane_elo.prediction.forecast import evaluate_model, run_historical
+
+        click.echo(f"\nRunning holdout {holdout_start}–{holdout_end}...")
+        model = model_class(result.best_config)
+        preds = run_historical(model, warmup_start, holdout_end)
+        holdout_metrics = evaluate_model(preds, holdout_start, holdout_end)
+        click.echo(
+            f"{'Holdout':<20} {holdout_metrics['log_likelihood']:>15.2f} {holdout_metrics['n_races']:>8}"
+        )
 
 
 @main.command()

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -143,6 +143,7 @@ def evaluate(
 @click.option("--model", "model_name", type=click.Choice(["endure-elo", "speed-elo"]), default="endure-elo")
 @click.option("--n-trials", type=int, default=100, help="Number of random-search trials.")
 @click.option("--seed", type=int, default=None, help="RNG seed for reproducibility.")
+@click.option("--predict-cap", type=int, default=15, help="Cap predictions to top-N drivers by rating (0=no cap).")
 @click.option("--top-n", type=int, default=10, help="Show top-N random search results.")
 def calibrate(
     warmup_start: int,
@@ -155,6 +156,7 @@ def calibrate(
     model_name: str,
     n_trials: int,
     seed: int | None,
+    predict_cap: int,
     top_n: int,
 ) -> None:
     """Calibrate k_max, phi_race, phi_season via random search + Nelder-Mead.
@@ -197,6 +199,7 @@ def calibrate(
             nl=True,
         )
 
+    cap = predict_cap or None
     result = run_calibrate(
         model_class,
         base_config,
@@ -207,6 +210,7 @@ def calibrate(
         val_end,
         n_trials=n_trials,
         seed=seed,
+        predict_cap=cap,
         on_trial=_on_trial,
     )
     click.echo("Random search done. Running Nelder-Mead refinement...")

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -256,7 +256,7 @@ def calibrate(
     if holdout_start is not None and holdout_end is not None:
         click.echo(f"\nRunning holdout {holdout_start}–{holdout_end}...")
         model = model_class(result.best_config)
-        preds = run_historical(model, warmup_start, holdout_end)
+        preds = run_historical(model, warmup_start, holdout_end, predict_cap=predict_cap)
         holdout_metrics = evaluate_model(preds, holdout_start, holdout_end)
         click.echo(f"{'Holdout':<20} {holdout_metrics['log_likelihood']:>15.2f} {holdout_metrics['n_races']:>8}")
 

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -182,10 +182,7 @@ def calibrate(
     model_class = EndureElo if model_name == "endure-elo" else SpeedElo
     base_config = ENDURE_ELO_DEFAULT if model_name == "endure-elo" else SPEED_ELO_DEFAULT
 
-    click.echo(
-        f"Calibrating {model_name}: warmup {warmup_start}, "
-        f"cal {cal_start}–{cal_end}, val {val_start}–{val_end}"
-    )
+    click.echo(f"Calibrating {model_name}: warmup {warmup_start}, cal {cal_start}–{cal_end}, val {val_start}–{val_end}")
     seed_suffix = f" (seed={seed})" if seed is not None else ""
     click.echo(f"Random search: {n_trials} trials{seed_suffix}")
 
@@ -245,9 +242,7 @@ def calibrate(
         model = model_class(result.best_config)
         preds = run_historical(model, warmup_start, holdout_end)
         holdout_metrics = evaluate_model(preds, holdout_start, holdout_end)
-        click.echo(
-            f"{'Holdout':<20} {holdout_metrics['log_likelihood']:>15.2f} {holdout_metrics['n_races']:>8}"
-        )
+        click.echo(f"{'Holdout':<20} {holdout_metrics['log_likelihood']:>15.2f} {holdout_metrics['n_races']:>8}")
 
 
 @main.command()

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import dataclasses
+import json
 import logging
+from pathlib import Path
 
 import click
 
@@ -145,6 +148,12 @@ def evaluate(
 @click.option("--seed", type=int, default=None, help="RNG seed for reproducibility.")
 @click.option("--predict-cap", type=int, default=15, help="Cap predictions to top-N drivers by rating (0=no cap).")
 @click.option("--top-n", type=int, default=10, help="Show top-N random search results.")
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, writable=True),
+    default=None,
+    help="Write calibrated config to this JSON file.",
+)
 def calibrate(
     warmup_start: int,
     cal_start: int,
@@ -158,6 +167,7 @@ def calibrate(
     seed: int | None,
     predict_cap: int,
     top_n: int,
+    output: str | None,
 ) -> None:
     """Calibrate k_max, phi_race, phi_season via random search + Nelder-Mead.
 
@@ -224,9 +234,9 @@ def calibrate(
     # Best config after refinement
     cfg = result.best_config
     click.echo("\nBest config (after Nelder-Mead refinement):")
-    click.echo(f"  k_max      = {cfg.k_max:.6f}")
-    click.echo(f"  phi_race   = {cfg.phi_race:.6f}")
-    click.echo(f"  phi_season = {cfg.phi_season:.6f}")
+    click.echo(f"  k_max      = {cfg.k_max:.4f}")
+    click.echo(f"  phi_race   = {cfg.phi_race:.4f}")
+    click.echo(f"  phi_season = {cfg.phi_season:.4f}")
 
     # Calibration / validation summary
     click.echo(f"\n{'Window':<20} {'Log-likelihood':>15} {'Races':>8}")
@@ -236,13 +246,17 @@ def calibrate(
 
     # Optional holdout
     if holdout_start is not None and holdout_end is not None:
-        from pitlane_elo.prediction.forecast import evaluate_model, run_historical
-
         click.echo(f"\nRunning holdout {holdout_start}–{holdout_end}...")
         model = model_class(result.best_config)
         preds = run_historical(model, warmup_start, holdout_end)
         holdout_metrics = evaluate_model(preds, holdout_start, holdout_end)
         click.echo(f"{'Holdout':<20} {holdout_metrics['log_likelihood']:>15.2f} {holdout_metrics['n_races']:>8}")
+
+    if output is not None:
+        payload = dataclasses.asdict(result.best_config)
+        payload = {k: round(v, 4) if isinstance(v, float) else v for k, v in payload.items()}
+        Path(output).write_text(json.dumps(payload, indent=2))
+        click.echo(f"\nConfig written to {output}")
 
 
 @main.command()

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -184,7 +184,18 @@ def calibrate(
         f"Calibrating {model_name}: warmup {warmup_start}, "
         f"cal {cal_start}–{cal_end}, val {val_start}–{val_end}"
     )
-    click.echo(f"Running {n_trials} random trials" + (f" (seed={seed})" if seed is not None else "") + "...")
+    seed_suffix = f" (seed={seed})" if seed is not None else ""
+    click.echo(f"Random search: {n_trials} trials{seed_suffix}")
+
+    best_ll_so_far: list[float] = []  # mutable cell for closure
+
+    def _on_trial(trial: int, total: int, ll: float) -> None:
+        if not best_ll_so_far or ll > best_ll_so_far[0]:
+            best_ll_so_far[:] = [ll]
+        click.echo(
+            f"  [{trial:>{len(str(total))}}/{total}] ll={ll:>10.2f}  best={best_ll_so_far[0]:>10.2f}",
+            nl=True,
+        )
 
     result = run_calibrate(
         model_class,
@@ -196,7 +207,9 @@ def calibrate(
         val_end,
         n_trials=n_trials,
         seed=seed,
+        on_trial=_on_trial,
     )
+    click.echo("Random search done. Running Nelder-Mead refinement...")
 
     # Top-N random search results
     click.echo(f"\nTop {min(top_n, len(result.random_results))} random search results:")

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -256,7 +256,7 @@ def calibrate(
     if holdout_start is not None and holdout_end is not None:
         click.echo(f"\nRunning holdout {holdout_start}–{holdout_end}...")
         model = model_class(result.best_config)
-        preds = run_historical(model, warmup_start, holdout_end, predict_cap=predict_cap)
+        preds = run_historical(model, warmup_start, holdout_end, predict_cap=cap)
         holdout_metrics = evaluate_model(preds, holdout_start, holdout_end)
         click.echo(f"{'Holdout':<20} {holdout_metrics['log_likelihood']:>15.2f} {holdout_metrics['n_races']:>8}")
 

--- a/packages/pitlane-elo/src/pitlane_elo/ratings/base.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings/base.py
@@ -56,7 +56,7 @@ class RatingModel(ABC):
         """Remove mechanical DNFs when configured to do so."""
         if self.config.exclude_mechanical_dnf:
             return [e for e in entries if e["dnf_category"] != "mechanical"]
-        return list(entries)
+        return entries
 
     def apply_season_decay(self, year: int) -> None:
         """Apply between-season rating decay.

--- a/packages/pitlane-elo/tests/test_calibration.py
+++ b/packages/pitlane-elo/tests/test_calibration.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from unittest.mock import patch
 
 import pytest
-
 from pitlane_elo.calibration import CalibrationResult, calibrate, random_search
 from pitlane_elo.config import ENDURE_ELO_DEFAULT
 from pitlane_elo.ratings.endure_elo import EndureElo
@@ -17,18 +16,26 @@ class TestRandomSearch:
     def test_returns_n_trials_results(self):
         with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
             results = random_search(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2024,
-                n_trials=5, seed=0,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2024,
+                n_trials=5,
+                seed=0,
             )
         assert len(results) == 5
 
     def test_results_sorted_descending(self):
         with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
             results = random_search(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2024,
-                n_trials=10, seed=1,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2024,
+                n_trials=10,
+                seed=1,
             )
         lls = [r["log_likelihood"] for r in results]
         assert lls == sorted(lls, reverse=True)
@@ -36,9 +43,13 @@ class TestRandomSearch:
     def test_result_keys(self):
         with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
             results = random_search(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2024,
-                n_trials=3, seed=2,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2024,
+                n_trials=3,
+                seed=2,
             )
         for r in results:
             assert set(r.keys()) == {"k_max", "phi_race", "phi_season", "log_likelihood"}
@@ -46,16 +57,24 @@ class TestRandomSearch:
     def test_seed_reproducibility(self):
         with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
             r1 = random_search(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2024,
-                n_trials=5, seed=42,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2024,
+                n_trials=5,
+                seed=42,
             )
             r2 = random_search(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2024,
-                n_trials=5, seed=42,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2024,
+                n_trials=5,
+                seed=42,
             )
-        for a, b in zip(r1, r2):
+        for a, b in zip(r1, r2, strict=True):
             assert a["k_max"] == pytest.approx(b["k_max"])
             assert a["phi_race"] == pytest.approx(b["phi_race"])
             assert a["phi_season"] == pytest.approx(b["phi_season"])
@@ -63,23 +82,35 @@ class TestRandomSearch:
     def test_different_seeds_differ(self):
         with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
             r1 = random_search(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2024,
-                n_trials=5, seed=0,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2024,
+                n_trials=5,
+                seed=0,
             )
             r2 = random_search(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2024,
-                n_trials=5, seed=99,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2024,
+                n_trials=5,
+                seed=99,
             )
-        assert any(a["k_max"] != pytest.approx(b["k_max"]) for a, b in zip(r1, r2))
+        assert any(a["k_max"] != pytest.approx(b["k_max"]) for a, b in zip(r1, r2, strict=True))
 
     def test_params_within_bounds(self):
         with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
             results = random_search(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2024,
-                n_trials=50, seed=7,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2024,
+                n_trials=50,
+                seed=7,
             )
         for r in results:
             assert 0.05 <= r["k_max"] <= 1.5
@@ -96,26 +127,40 @@ class TestCalibrate:
     """Unit tests for calibrate(); _score is mocked to avoid expensive model runs."""
 
     def test_returns_calibration_result(self):
-        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
-             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
-             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+        with (
+            patch("pitlane_elo.calibration._score", side_effect=_fake_score),
+            patch("pitlane_elo.calibration.run_historical", return_value=[]),
+            patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}),
+        ):
             result = calibrate(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2023,
-                val_start=2024, val_end=2024,
-                n_trials=5, seed=0,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2023,
+                val_start=2024,
+                val_end=2024,
+                n_trials=5,
+                seed=0,
             )
         assert isinstance(result, CalibrationResult)
 
     def test_best_config_has_valid_params(self):
-        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
-             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
-             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+        with (
+            patch("pitlane_elo.calibration._score", side_effect=_fake_score),
+            patch("pitlane_elo.calibration.run_historical", return_value=[]),
+            patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}),
+        ):
             result = calibrate(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2023,
-                val_start=2024, val_end=2024,
-                n_trials=5, seed=0,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2023,
+                val_start=2024,
+                val_end=2024,
+                n_trials=5,
+                seed=0,
             )
         cfg = result.best_config
         assert 0.01 <= cfg.k_max <= 2.0
@@ -123,39 +168,60 @@ class TestCalibrate:
         assert 0.5 <= cfg.phi_season < 1.0
 
     def test_random_results_count(self):
-        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
-             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
-             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+        with (
+            patch("pitlane_elo.calibration._score", side_effect=_fake_score),
+            patch("pitlane_elo.calibration.run_historical", return_value=[]),
+            patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}),
+        ):
             result = calibrate(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2023,
-                val_start=2024, val_end=2024,
-                n_trials=4, seed=0,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2023,
+                val_start=2024,
+                val_end=2024,
+                n_trials=4,
+                seed=0,
             )
         assert len(result.random_results) == 4
 
     def test_best_config_name_suffix(self):
-        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
-             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
-             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+        with (
+            patch("pitlane_elo.calibration._score", side_effect=_fake_score),
+            patch("pitlane_elo.calibration.run_historical", return_value=[]),
+            patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}),
+        ):
             result = calibrate(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2023,
-                val_start=2024, val_end=2024,
-                n_trials=5, seed=0,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2023,
+                val_start=2024,
+                val_end=2024,
+                n_trials=5,
+                seed=0,
             )
         assert result.best_config.name.endswith("-calibrated")
 
     def test_nelder_mead_improves_on_random_best(self):
         # Nelder-Mead should find params closer to the fake optimum (0.4, 0.99, 0.90)
-        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
-             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
-             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+        with (
+            patch("pitlane_elo.calibration._score", side_effect=_fake_score),
+            patch("pitlane_elo.calibration.run_historical", return_value=[]),
+            patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}),
+        ):
             result = calibrate(
-                EndureElo, ENDURE_ELO_DEFAULT,
-                warmup_start=2023, cal_start=2023, cal_end=2023,
-                val_start=2024, val_end=2024,
-                n_trials=10, seed=0,
+                EndureElo,
+                ENDURE_ELO_DEFAULT,
+                warmup_start=2023,
+                cal_start=2023,
+                cal_end=2023,
+                val_start=2024,
+                val_end=2024,
+                n_trials=10,
+                seed=0,
             )
         cfg = result.best_config
         assert abs(cfg.k_max - 0.4) < 0.05

--- a/packages/pitlane-elo/tests/test_calibration.py
+++ b/packages/pitlane-elo/tests/test_calibration.py
@@ -1,0 +1,163 @@
+"""Tests for the calibration module."""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from pitlane_elo.calibration import CalibrationResult, calibrate, random_search
+from pitlane_elo.config import ENDURE_ELO_DEFAULT
+from pitlane_elo.ratings.endure_elo import EndureElo
+
+
+class TestRandomSearch:
+    """Unit tests for random_search(); _score is mocked — tests cover sampling behavior."""
+
+    def test_returns_n_trials_results(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
+            results = random_search(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2024,
+                n_trials=5, seed=0,
+            )
+        assert len(results) == 5
+
+    def test_results_sorted_descending(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
+            results = random_search(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2024,
+                n_trials=10, seed=1,
+            )
+        lls = [r["log_likelihood"] for r in results]
+        assert lls == sorted(lls, reverse=True)
+
+    def test_result_keys(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
+            results = random_search(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2024,
+                n_trials=3, seed=2,
+            )
+        for r in results:
+            assert set(r.keys()) == {"k_max", "phi_race", "phi_season", "log_likelihood"}
+
+    def test_seed_reproducibility(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
+            r1 = random_search(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2024,
+                n_trials=5, seed=42,
+            )
+            r2 = random_search(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2024,
+                n_trials=5, seed=42,
+            )
+        for a, b in zip(r1, r2):
+            assert a["k_max"] == pytest.approx(b["k_max"])
+            assert a["phi_race"] == pytest.approx(b["phi_race"])
+            assert a["phi_season"] == pytest.approx(b["phi_season"])
+
+    def test_different_seeds_differ(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
+            r1 = random_search(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2024,
+                n_trials=5, seed=0,
+            )
+            r2 = random_search(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2024,
+                n_trials=5, seed=99,
+            )
+        assert any(a["k_max"] != pytest.approx(b["k_max"]) for a, b in zip(r1, r2))
+
+    def test_params_within_bounds(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score):
+            results = random_search(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2024,
+                n_trials=50, seed=7,
+            )
+        for r in results:
+            assert 0.05 <= r["k_max"] <= 1.5
+            assert 0.90 <= r["phi_race"] <= 0.999
+            assert 0.60 <= r["phi_season"] <= 0.99
+
+
+def _fake_score(k_max, phi_race, phi_season, **_kwargs):
+    """Fake scoring function: best when k_max=0.4, phi_race=0.99, phi_season=0.90."""
+    return -(abs(k_max - 0.4) + abs(phi_race - 0.99) + abs(phi_season - 0.90))
+
+
+class TestCalibrate:
+    """Unit tests for calibrate(); _score is mocked to avoid expensive model runs."""
+
+    def test_returns_calibration_result(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
+             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
+             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+            result = calibrate(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2023,
+                val_start=2024, val_end=2024,
+                n_trials=5, seed=0,
+            )
+        assert isinstance(result, CalibrationResult)
+
+    def test_best_config_has_valid_params(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
+             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
+             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+            result = calibrate(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2023,
+                val_start=2024, val_end=2024,
+                n_trials=5, seed=0,
+            )
+        cfg = result.best_config
+        assert 0.01 <= cfg.k_max <= 2.0
+        assert 0.5 <= cfg.phi_race < 1.0
+        assert 0.5 <= cfg.phi_season < 1.0
+
+    def test_random_results_count(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
+             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
+             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+            result = calibrate(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2023,
+                val_start=2024, val_end=2024,
+                n_trials=4, seed=0,
+            )
+        assert len(result.random_results) == 4
+
+    def test_best_config_name_suffix(self):
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
+             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
+             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+            result = calibrate(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2023,
+                val_start=2024, val_end=2024,
+                n_trials=5, seed=0,
+            )
+        assert result.best_config.name.endswith("-calibrated")
+
+    def test_nelder_mead_improves_on_random_best(self):
+        # Nelder-Mead should find params closer to the fake optimum (0.4, 0.99, 0.90)
+        with patch("pitlane_elo.calibration._score", side_effect=_fake_score), \
+             patch("pitlane_elo.calibration.run_historical", return_value=[]), \
+             patch("pitlane_elo.calibration.evaluate_model", return_value={"log_likelihood": -10.0, "n_races": 5}):
+            result = calibrate(
+                EndureElo, ENDURE_ELO_DEFAULT,
+                warmup_start=2023, cal_start=2023, cal_end=2023,
+                val_start=2024, val_end=2024,
+                n_trials=10, seed=0,
+            )
+        cfg = result.best_config
+        assert abs(cfg.k_max - 0.4) < 0.05
+        assert abs(cfg.phi_race - 0.99) < 0.005
+        assert abs(cfg.phi_season - 0.90) < 0.01

--- a/uv.lock
+++ b/uv.lock
@@ -2315,6 +2315,12 @@ notebooks = [
     { name = "pandas" },
 ]
 
+[package.dev-dependencies]
+dev = [
+    { name = "py-spy" },
+    { name = "pyinstrument" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.1.0" },
@@ -2327,6 +2333,12 @@ requires-dist = [
     { name = "scipy", specifier = ">=1.10" },
 ]
 provides-extras = ["notebooks"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "py-spy", specifier = ">=0.4.1" },
+    { name = "pyinstrument", specifier = ">=5.1.2" },
+]
 
 [[package]]
 name = "pitlane-web"
@@ -2468,6 +2480,21 @@ wheels = [
 ]
 
 [[package]]
+name = "py-spy"
+version = "0.4.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/e2/ff811a367028b87e86714945bb9ecb5c1cc69114a8039a67b3a862cef921/py_spy-0.4.1.tar.gz", hash = "sha256:e53aa53daa2e47c2eef97dd2455b47bb3a7e7f962796a86cc3e7dbde8e6f4db4", size = 244726, upload-time = "2025-07-31T19:33:25.172Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/e3/3a32500d845bdd94f6a2b4ed6244982f42ec2bc64602ea8fcfe900678ae7/py_spy-0.4.1-py2.py3-none-macosx_10_12_x86_64.macosx_11_0_arm64.macosx_10_12_universal2.whl", hash = "sha256:809094208c6256c8f4ccadd31e9a513fe2429253f48e20066879239ba12cd8cc", size = 3682508, upload-time = "2025-07-31T19:33:13.753Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/bf/e4d280e9e0bec71d39fc646654097027d4bbe8e04af18fb68e49afcff404/py_spy-0.4.1-py2.py3-none-macosx_11_0_arm64.whl", hash = "sha256:1fb8bf71ab8df95a95cc387deed6552934c50feef2cf6456bc06692a5508fd0c", size = 1796395, upload-time = "2025-07-31T19:33:15.325Z" },
+    { url = "https://files.pythonhosted.org/packages/df/79/9ed50bb0a9de63ed023aa2db8b6265b04a7760d98c61eb54def6a5fddb68/py_spy-0.4.1-py2.py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ee776b9d512a011d1ad3907ed53ae32ce2f3d9ff3e1782236554e22103b5c084", size = 2034938, upload-time = "2025-07-31T19:33:17.194Z" },
+    { url = "https://files.pythonhosted.org/packages/53/a5/36862e3eea59f729dfb70ee6f9e14b051d8ddce1aa7e70e0b81d9fe18536/py_spy-0.4.1-py2.py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:532d3525538254d1859b49de1fbe9744df6b8865657c9f0e444bf36ce3f19226", size = 2658968, upload-time = "2025-07-31T19:33:18.916Z" },
+    { url = "https://files.pythonhosted.org/packages/08/f8/9ea0b586b065a623f591e5e7961282ec944b5fbbdca33186c7c0296645b3/py_spy-0.4.1-py2.py3-none-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4972c21890b6814017e39ac233c22572c4a61fd874524ebc5ccab0f2237aee0a", size = 2147541, upload-time = "2025-07-31T19:33:20.565Z" },
+    { url = "https://files.pythonhosted.org/packages/68/fb/bc7f639aed026bca6e7beb1e33f6951e16b7d315594e7635a4f7d21d63f4/py_spy-0.4.1-py2.py3-none-manylinux_2_5_x86_64.manylinux1_x86_64.whl", hash = "sha256:6a80ec05eb8a6883863a367c6a4d4f2d57de68466f7956b6367d4edd5c61bb29", size = 2763338, upload-time = "2025-07-31T19:33:22.202Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/da/fcc9a9fcd4ca946ff402cff20348e838b051d69f50f5d1f5dca4cd3c5eb8/py_spy-0.4.1-py2.py3-none-win_amd64.whl", hash = "sha256:d92e522bd40e9bf7d87c204033ce5bb5c828fca45fa28d970f58d71128069fdc", size = 1818784, upload-time = "2025-07-31T19:33:23.802Z" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2583,6 +2610,46 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b0/77/a5b8c569bf593b0140bde72ea885a803b82086995367bf2037de0159d924/pygments-2.19.2.tar.gz", hash = "sha256:636cb2477cec7f8952536970bc533bc43743542f70392ae026374600add5b887", size = 4968631, upload-time = "2025-06-21T13:39:12.283Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/21/705964c7812476f378728bdf590ca4b771ec72385c533964653c68e86bdc/pygments-2.19.2-py3-none-any.whl", hash = "sha256:86540386c03d588bb81d44bc3928634ff26449851e99741617ecb9037ee5ec0b", size = 1225217, upload-time = "2025-06-21T13:39:07.939Z" },
+]
+
+[[package]]
+name = "pyinstrument"
+version = "5.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/32/7f/d3c4ef7c43f3294bd5a475dfa6f295a9fee5243c292d5c8122044fa83bcb/pyinstrument-5.1.2.tar.gz", hash = "sha256:af149d672da9493fa37334a1cc68f7b80c3e6cb9fd99b9e426c447db5c650bf0", size = 266889, upload-time = "2026-01-04T18:38:58.464Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/d9/8fa5571ddd21b2b7189bd8b0bb4e90be1659a54dda5af51c7f6bf2b5666f/pyinstrument-5.1.2-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:2519865d4bf58936f2506c1c46a82d29a20f3239aa50c941df1ca9618c7da5f0", size = 131419, upload-time = "2026-01-04T18:37:46.843Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/50/0512adb83cadfeaa1a215dc9784defff5043c5aa052d15015e3d8013af75/pyinstrument-5.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:059442106b8b5de29ae5ac1bdc20d044fed4da534b8caba434b6ffb119037bf5", size = 124446, upload-time = "2026-01-04T18:37:48.572Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/78/c45f0b668fb3c8c0d32058a451a8e1d34737cd7586387982185e12df1977/pyinstrument-5.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cd51f2d54fc39a4cfd73ba6be27cd0187123132ce3f445b639bff5e1b23d7e26", size = 149694, upload-time = "2026-01-04T18:37:49.876Z" },
+    { url = "https://files.pythonhosted.org/packages/91/4d/2ca3ca9906ce6e05070f431c54d54ccbaf57a980cfa58032d35b0b0ac1f8/pyinstrument-5.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:12af1e83795b6c640d657d339014dd1ff718b182dec736d7d1f1d8a97534eb53", size = 148461, upload-time = "2026-01-04T18:37:51.544Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d2/bfe84a4326172ef68655b65b49fd041eeb94c8e59ee47258589b8b79dd3b/pyinstrument-5.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2565513658e742c5eb691a779cb29d19d01bc9ee951d0eb76482e9f343c38c2e", size = 148560, upload-time = "2026-01-04T18:37:52.931Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/00/db7f5def351e869230b0165828c4edacbf3fdda8d66aff30dd73a62082c2/pyinstrument-5.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:5afd0ba788a1d112da49fb77966918e01df1f9e7d62e72894d82f7acb0996c2d", size = 148178, upload-time = "2026-01-04T18:37:54.278Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/bc/aea3329576e20b987d205027b8e6442ece845d681b9f9d8682d5404f81f3/pyinstrument-5.1.2-cp312-cp312-win32.whl", hash = "sha256:554077b031b278593cb2301f0057be771ea62a729878c69aaf29fcdfb7b71281", size = 125927, upload-time = "2026-01-04T18:37:55.615Z" },
+    { url = "https://files.pythonhosted.org/packages/14/e2/d928434ec3a840478e95fd0d73b0dfc0b8060a07b06f4b45e9df30444e9a/pyinstrument-5.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:55a905384ba43efc924b8863aa6cfd276f029e4aa70c4a0e3b7389e27b191e45", size = 126675, upload-time = "2026-01-04T18:37:57.278Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/8e/b9aea969eec67c129652000446384d550a0df45c297adc9fd74da2f8482c/pyinstrument-5.1.2-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:7b8bab2334bf1d4c9e92d61db574300b914b594588a6b6dd67c45450152dfc29", size = 131418, upload-time = "2026-01-04T18:37:58.642Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/62/76418eb29b5591f3e5500369a6777ce928135c3aa6ccdb0c861a9c6ca93b/pyinstrument-5.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:13dcc138a61298ef4994b7aebff509d2c06db89dfd6e2021f0b9cd96aaa44ec3", size = 124448, upload-time = "2026-01-04T18:37:59.95Z" },
+    { url = "https://files.pythonhosted.org/packages/07/73/874bccc04bcf6f4babc3de1a9568e209e7e40998563974f5030b0fb4d3e0/pyinstrument-5.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c8abd4a7ffa2e7f9e00039a5e549e8eebc80d7ca8d43f0fb51a50ff2b117ce4a", size = 149853, upload-time = "2026-01-04T18:38:01.405Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/85/268446c4388d77ff4abdeaff202356e1527b3ff9576f5587443a24980bec/pyinstrument-5.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:eb3a05108edebc30f31e2c69c904576042f1158b2513ab80adc08f7848a7a8f0", size = 148641, upload-time = "2026-01-04T18:38:03.086Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/15/4f8dea3381483e68d00582a9b823a21a088acfe77a847a7991a1a8feed76/pyinstrument-5.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f70d588b53f3f35829d1d1ddfa05e07fcebf1434b3b1509d542ca317d8e9a2a5", size = 148674, upload-time = "2026-01-04T18:38:04.805Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/61/72c180454b6511d5b90166f8828e1bab3b45d0489952a1fe48c5c585233d/pyinstrument-5.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:b007327e0d6a6a01d5064883dd27c19996f044ce7488d507826fee7884e6a32e", size = 148315, upload-time = "2026-01-04T18:38:06.114Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/f0/4c27cebddf22a8840bd8b419366bb321ce41f921ca1893e309c932ab28bf/pyinstrument-5.1.2-cp313-cp313-win32.whl", hash = "sha256:9ba0e6b17a7e86c3dc02d208e4c25506e8f914d9964ae89449f1f37f0b70abc0", size = 125926, upload-time = "2026-01-04T18:38:07.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/20/6b1bee88ddef065b0df3a3ba4ba60ed8a9ca443d5cded7152a8a9750914f/pyinstrument-5.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:660d7fc486a839814db0b2f716bc13d8b99b9c780aaeb47f74a70a34adc02a7b", size = 126678, upload-time = "2026-01-04T18:38:08.826Z" },
+    { url = "https://files.pythonhosted.org/packages/66/0f/7d5154c92904bdf25be067a7fe4cad4ba48919f16ccbb51bb953d9ae1a20/pyinstrument-5.1.2-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:0baed297beee2bb9897e737bbd89e3b9d45a2fbbea9f1ad4e809007d780a9b1e", size = 131388, upload-time = "2026-01-04T18:38:10.491Z" },
+    { url = "https://files.pythonhosted.org/packages/17/28/bf83231a3f951e11b4dfaf160e1eeba1ce29377eab30e3d2eb6ee22ff3ba/pyinstrument-5.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:ebb910a32a45bde6c3fc30c578efc28a54517990e11e94b5e48a0d5479728568", size = 124456, upload-time = "2026-01-04T18:38:11.792Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/98/762cf10896d907268629e1db08a48f128984a53e8d92b99ea96f862597e5/pyinstrument-5.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bad403c157f9c6dba7f731a6fca5bfcd8ca2701a39bcc717dcc6e0b10055ffc4", size = 149594, upload-time = "2026-01-04T18:38:13.434Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/1b/48580e16e623d89af58b89c552c95a2ae65f70a1f4fab1d97879f34791db/pyinstrument-5.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2f456cabdb95fd343c798a7f2a56688b028f981522e283c5f59bd59195b66df5", size = 148339, upload-time = "2026-01-04T18:38:14.767Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7e/38157a8a6ec67789d8ee109fd09877ea3340df44e1a7add8f249e30a8ade/pyinstrument-5.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:4e9c4dcc1f2c4a0cd6b576e3604abc37496a7868243c9a1443ad3b9db69d590f", size = 148485, upload-time = "2026-01-04T18:38:16.121Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/34/31ee72b19cfc48a82801024b5d653f07982154a11381a3ae65bbfdbf2c7b/pyinstrument-5.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:acf93b128328c6d80fdb85431068ac17508f0f7845e89505b0ea6130dead5ca6", size = 148106, upload-time = "2026-01-04T18:38:17.623Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/b4/7ab20243187262d66ab062778b1ccac4ca55090752f32a83f603f4e5e3a2/pyinstrument-5.1.2-cp314-cp314-win32.whl", hash = "sha256:9c7f0167903ecff8b1d744f7e37b2bd4918e05a69cca724cb112f5ed59d1e41b", size = 126593, upload-time = "2026-01-04T18:38:18.968Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/a0/db6a8ae3182546227f5a043b1be29b8d5f98bf973e20d922981ef206de85/pyinstrument-5.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:ce3f6b1f9a2b5d74819ecc07d631eadececf915f551474a75ad65ac580ec5a0e", size = 127358, upload-time = "2026-01-04T18:38:20.28Z" },
+    { url = "https://files.pythonhosted.org/packages/59/d2/719f439972b3f80e35fb5b1bcd888c3218d60dbc91957b99ffafd7ac9221/pyinstrument-5.1.2-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:af8651b239049accbeecd389d35823233f649446f76f47fd005316b05d08cef2", size = 132317, upload-time = "2026-01-04T18:38:21.669Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/1c/0ebfef69ae926665fae635424c5647411235c3689c9a9ad69fd68de6cae2/pyinstrument-5.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c6082f1c3e43e1d22834e91ba8975f0080186df4018a04b4dd29f9623c59df1d", size = 124917, upload-time = "2026-01-04T18:38:23.385Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/ee/5599f769f515a0f1c97443edc7394fe2b9829bf39f404c046499c1a62378/pyinstrument-5.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c031eb066ddc16425e1e2f56aad5c1ce1e27b2432a70329e5385b85e812decee", size = 157407, upload-time = "2026-01-04T18:38:24.774Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/40/32aa865252288caef301237488ee309bd6701125888bf453d23ab764e357/pyinstrument-5.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f447ec391cad30667ba412dce41607aaa20d4a2496a7ab867e0c199f0fe3ae3d", size = 155068, upload-time = "2026-01-04T18:38:26.112Z" },
+    { url = "https://files.pythonhosted.org/packages/91/68/0b56a1540fe1c357dfcda82d4f5b52c87fada5962cbf18703ea39ccbbe69/pyinstrument-5.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:50299bddfc1fe0039898f895b10ef12f9db08acffb4d85326fad589cda24d2ee", size = 155186, upload-time = "2026-01-04T18:38:27.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/48/7ef84abfc3e41148cf993095214f104e75ecff585e94c6e8be001e672573/pyinstrument-5.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a193ff08825ece115ececa136832acb14c491c77ab1e6b6a361905df8753d5c6", size = 153979, upload-time = "2026-01-04T18:38:29.236Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/cf/a28ad117d58b33c1d74bcdfbbcf1603b67346883800ac7d510cff8d3bcee/pyinstrument-5.1.2-cp314-cp314t-win32.whl", hash = "sha256:de887ba19e1057bd2d86e6584f17788516a890ae6fe1b7eed9927873f416b4d8", size = 127267, upload-time = "2026-01-04T18:38:30.619Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/97/03635143a12a5d941f545548b00f8ac39d35565321a2effb4154ed267338/pyinstrument-5.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:b6a71f5e7f53c86c9b476b30cf19509463a63581ef17ddbd8680fee37ae509db", size = 128164, upload-time = "2026-01-04T18:38:32.281Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `calibration.py` with `random_search()` + `calibrate()`: random search over `(k_max, phi_race, phi_season)` followed by Nelder-Mead local refinement
- Adds `pitlane-elo calibrate` CLI command with per-trial progress output and `--predict-cap` to keep each trial fast
- 11 unit tests (all mocked, 0.22s) covering sampling behavior, reproducibility, bounds, and optimizer convergence

## Temporal split (anchored to regulation changes)

| Window | Years | Purpose |
|--------|-------|---------| 
| Warmup | 1970–1979 | Burn-in; not scored |
| Calibration | 1980–2013 | Parameter selection |
| Validation | 2014–2021 | Generalization across 2014 hybrid era |
| Holdout | 2022–2025 | Truly unseen; optional, reported only |

## Results

**Baseline (default params, 2022–2025 holdout):** log-likelihood = -176.08 across 92 races

**Best config after calibration + Nelder-Mead refinement:**
```
k_max      = 0.866504
phi_race   = 1.000000
phi_season = 0.947189
```

| Window | Log-likelihood | Races |
|--------|---------------|-------|
| Calibration | -1130.35 | 566 |
| Validation | -252.46 | 160 |
| Holdout (2022–2025) | -142.42 | 92 |

Holdout improvement vs baseline: **+33.66 log-likelihood** (-142.42 vs -176.08)

## Test plan

- [x] `uv run --directory packages/pitlane-elo pytest tests/test_calibration.py` — 11 passed in 0.22s
- [x] `ruff check` — clean
- [x] Smoke test on production DB: `pitlane-elo calibrate --n-trials 10 --seed 42`
- [x] Full run: `pitlane-elo calibrate --holdout-start 2022 --holdout-end 2025 --n-trials 100 --seed 42`

🤖 Generated with [Claude Code](https://claude.com/claude-code)