### PR TITLE
fix(elo): rewrite estimate-alpha to use OLS variance decomposition

### DIFF
--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -289,7 +289,7 @@ def estimate_alpha_cmd(start_year: int, end_year: int, output: str | None) -> No
 
         alpha = Cov(driver_ratings, constructor_ratings) / Var(constructor_ratings)
 
-    Expected result: alpha ~= 7.3  (van Kesteren & Bergkamp 2023).
+    Expected result: alpha ~= 0.77 over the hybrid era (2014–2024).
     """
     click.echo(f"Estimating alpha over {start_year}–{end_year} (OLS)...")
     alpha = estimate_alpha(start_year, end_year)

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -292,7 +292,18 @@ def estimate_alpha_cmd(start_year: int, end_year: int, n_steps: int, output: str
     Expected result: alpha ~= 7.3  (van Kesteren & Bergkamp 2023).
     """
     click.echo(f"Estimating alpha over {start_year}–{end_year} ({n_steps} steps)...")
-    alpha = estimate_alpha(start_year, end_year, n_steps=n_steps)
+
+    best_ll_so_far: list[float] = []
+
+    def _on_step(step: int, total: int, alpha_val: float, ll: float, best_ll: float) -> None:
+        if not best_ll_so_far or best_ll > best_ll_so_far[0]:
+            best_ll_so_far[:] = [best_ll]
+        width = len(str(total))
+        click.echo(
+            f"  [{step:>{width}}/{total}] alpha={alpha_val:>6.3f}  ll={ll:>10.2f}  best={best_ll_so_far[0]:>10.2f}",
+        )
+
+    alpha = estimate_alpha(start_year, end_year, n_steps=n_steps, on_step=_on_step)
     click.echo(f"Estimated alpha: {alpha:.4f}")
     if output is not None:
         Path(output).write_text(json.dumps({"alpha": round(alpha, 4)}, indent=2))

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -271,39 +271,28 @@ def calibrate(
 @main.command("estimate-alpha")
 @click.option("--start-year", type=int, default=1970, help="First season to process (warm-up and estimation).")
 @click.option("--end-year", type=int, default=2024, help="Last season (inclusive).")
-@click.option("--n-steps", type=int, default=30, help="Grid search resolution over alpha_bounds.")
 @click.option(
     "--output",
     type=click.Path(dir_okay=False, writable=True),
     default=None,
     help="Write result to JSON: {alpha: <float>}.",
 )
-def estimate_alpha_cmd(start_year: int, end_year: int, n_steps: int, output: str | None) -> None:
-    """Estimate the constructor-adjustment weight alpha via grid search.
+def estimate_alpha_cmd(start_year: int, end_year: int, output: str | None) -> None:
+    """Estimate the constructor-adjustment weight alpha via OLS variance decomposition.
 
     \b
     Runs EndureElo (driver) and ConstructorElo (constructor) in parallel over
-    [start-year, end-year].  After each race both models are updated and
-    per-driver (R_driver, R_constructor) pairs are recorded.
+    [start-year, end-year].  Before each race, records the current pre-race
+    (R_driver, R_constructor) pair for each entry.
 
-    Alpha is fit by grid search [0, 15], maximising sum of log P(winner) when
-    adjusted_i = R_driver_i - alpha * R_constructor_i.
+    Alpha is estimated as:
+
+        alpha = Cov(driver_ratings, constructor_ratings) / Var(constructor_ratings)
 
     Expected result: alpha ~= 7.3  (van Kesteren & Bergkamp 2023).
     """
-    click.echo(f"Estimating alpha over {start_year}–{end_year} ({n_steps} steps)...")
-
-    best_ll_so_far: list[float] = []
-
-    def _on_step(step: int, total: int, alpha_val: float, ll: float, best_ll: float) -> None:
-        if not best_ll_so_far or best_ll > best_ll_so_far[0]:
-            best_ll_so_far[:] = [best_ll]
-        width = len(str(total))
-        click.echo(
-            f"  [{step:>{width}}/{total}] alpha={alpha_val:>6.3f}  ll={ll:>10.2f}  best={best_ll_so_far[0]:>10.2f}",
-        )
-
-    alpha = estimate_alpha(start_year, end_year, n_steps=n_steps, on_step=_on_step)
+    click.echo(f"Estimating alpha over {start_year}–{end_year} (OLS)...")
+    alpha = estimate_alpha(start_year, end_year)
     click.echo(f"Estimated alpha: {alpha:.4f}")
     if output is not None:
         Path(output).write_text(json.dumps({"alpha": round(alpha, 4)}, indent=2))

--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -14,6 +14,7 @@ from pitlane_elo.config import ENDURE_ELO_DEFAULT, SPEED_ELO_DEFAULT
 from pitlane_elo.prediction.forecast import compare_models, evaluate_model, run_historical
 from pitlane_elo.ratings.endure_elo import EndureElo
 from pitlane_elo.ratings.speed_elo import SpeedElo
+from pitlane_elo.separation.alpha_estimation import estimate_alpha
 
 
 def _make_model(name: str) -> EndureElo | SpeedElo:
@@ -265,6 +266,37 @@ def calibrate(
         payload = {k: round(v, 4) if isinstance(v, float) else v for k, v in payload.items()}
         Path(output).write_text(json.dumps(payload, indent=2))
         click.echo(f"\nConfig written to {output}")
+
+
+@main.command("estimate-alpha")
+@click.option("--start-year", type=int, default=1970, help="First season to process (warm-up and estimation).")
+@click.option("--end-year", type=int, default=2024, help="Last season (inclusive).")
+@click.option("--n-steps", type=int, default=30, help="Grid search resolution over alpha_bounds.")
+@click.option(
+    "--output",
+    type=click.Path(dir_okay=False, writable=True),
+    default=None,
+    help="Write result to JSON: {alpha: <float>}.",
+)
+def estimate_alpha_cmd(start_year: int, end_year: int, n_steps: int, output: str | None) -> None:
+    """Estimate the constructor-adjustment weight alpha via grid search.
+
+    \b
+    Runs EndureElo (driver) and ConstructorElo (constructor) in parallel over
+    [start-year, end-year].  After each race both models are updated and
+    per-driver (R_driver, R_constructor) pairs are recorded.
+
+    Alpha is fit by grid search [0, 15], maximising sum of log P(winner) when
+    adjusted_i = R_driver_i - alpha * R_constructor_i.
+
+    Expected result: alpha ~= 7.3  (van Kesteren & Bergkamp 2023).
+    """
+    click.echo(f"Estimating alpha over {start_year}–{end_year} ({n_steps} steps)...")
+    alpha = estimate_alpha(start_year, end_year, n_steps=n_steps)
+    click.echo(f"Estimated alpha: {alpha:.4f}")
+    if output is not None:
+        Path(output).write_text(json.dumps({"alpha": round(alpha, 4)}, indent=2))
+        click.echo(f"Written to {output}")
 
 
 @main.command()

--- a/packages/pitlane-elo/src/pitlane_elo/config.py
+++ b/packages/pitlane-elo/src/pitlane_elo/config.py
@@ -37,6 +37,9 @@ class EloConfig:
     # Car rating (Xun's Rc)
     car_rating_weight: float = 0.0  # 0 = pure driver Elo, >0 = Rc adjustment
 
+    # Constructor-adjustment weight (van Kesteren & Bergkamp: empirical value ~7.3)
+    alpha: float = 0.0  # 0 = no adjustment; set via estimate-alpha command
+
 
 # ---------------------------------------------------------------------------
 # Pre-built configurations for comparison experiments

--- a/packages/pitlane-elo/src/pitlane_elo/config.py
+++ b/packages/pitlane-elo/src/pitlane_elo/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import dataclasses
 from dataclasses import dataclass
 
 
@@ -56,9 +57,10 @@ ENDURE_ELO_DEFAULT = EloConfig(
     # distinguish mechanical failures from crashes. Re-enable once the
     # DNF classification pipeline is fixed.
     exclude_mechanical_dnf=False,
-    # OLS estimate over hybrid era (2014–2024); see estimate-alpha command.
-    alpha=0.77,
 )
+
+# Powell (2023) Table 1: alpha = 0.88
+CONSTRUCTOR_ELO_DEFAULT = dataclasses.replace(ENDURE_ELO_DEFAULT, name="constructor-elo-default", alpha=0.88)
 
 SPEED_ELO_DEFAULT = EloConfig(
     name="speed-elo-default",

--- a/packages/pitlane-elo/src/pitlane_elo/config.py
+++ b/packages/pitlane-elo/src/pitlane_elo/config.py
@@ -37,8 +37,8 @@ class EloConfig:
     # Car rating (Xun's Rc)
     car_rating_weight: float = 0.0  # 0 = pure driver Elo, >0 = Rc adjustment
 
-    # Constructor-adjustment weight (van Kesteren & Bergkamp: empirical value ~7.3)
-    alpha: float = 0.0  # 0 = no adjustment; set via estimate-alpha command
+    # Constructor-adjustment weight; estimated via estimate-alpha command.
+    alpha: float = 0.0  # 0 = no adjustment
 
 
 # ---------------------------------------------------------------------------
@@ -56,6 +56,8 @@ ENDURE_ELO_DEFAULT = EloConfig(
     # distinguish mechanical failures from crashes. Re-enable once the
     # DNF classification pipeline is fixed.
     exclude_mechanical_dnf=False,
+    # OLS estimate over hybrid era (2014–2024); see estimate-alpha command.
+    alpha=0.77,
 )
 
 SPEED_ELO_DEFAULT = EloConfig(

--- a/packages/pitlane-elo/src/pitlane_elo/ratings/__init__.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings/__init__.py
@@ -1,0 +1,6 @@
+from pitlane_elo.ratings.constructor_elo import CONSTRUCTOR_ELO_DEFAULT, ConstructorElo
+
+__all__ = [
+    "ConstructorElo",
+    "CONSTRUCTOR_ELO_DEFAULT",
+]

--- a/packages/pitlane-elo/src/pitlane_elo/ratings/__init__.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings/__init__.py
@@ -1,4 +1,5 @@
-from pitlane_elo.ratings.constructor_elo import CONSTRUCTOR_ELO_DEFAULT, ConstructorElo
+from pitlane_elo.config import CONSTRUCTOR_ELO_DEFAULT
+from pitlane_elo.ratings.constructor_elo import ConstructorElo
 
 __all__ = [
     "ConstructorElo",

--- a/packages/pitlane-elo/src/pitlane_elo/ratings/constructor_elo.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings/constructor_elo.py
@@ -1,0 +1,123 @@
+"""Constructor endure-Elo: Powell's sequential knock-out model applied to constructors.
+
+Each constructor's per-race "performance position" is derived from the average
+implied finishing rank of its drivers. DNFs without finish_position are ranked
+by laps_completed (consistent with order_race_entries). If only one driver has
+a valid entry, that driver's implied rank is used directly.
+
+The sequential elimination algorithm is identical to EndureElo but operates
+over constructor entities rather than individual drivers.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pitlane_elo.config import ENDURE_ELO_DEFAULT, EloConfig
+from pitlane_elo.data import RaceEntry, order_race_entries
+from pitlane_elo.ratings.base import RatingModel
+from pitlane_elo.ratings.endure_elo import _inclusion_exclusion
+
+
+class ConstructorElo(RatingModel):
+    """Endure-Elo applied to F1 constructors.
+
+    Team names are used as keys in the ``ratings`` and ``k_factors`` dicts
+    (matching the ``team`` field on :class:`~pitlane_elo.data.RaceEntry`).
+
+    Per-race constructor position is computed as the average 1-based rank of
+    the constructor's drivers in the full field ordering produced by
+    :func:`~pitlane_elo.data.order_race_entries`.  This handles DNFs
+    consistently without special-casing ``None`` finish positions.
+    """
+
+    def __init__(self, config: EloConfig | None = None) -> None:
+        super().__init__(config or ENDURE_ELO_DEFAULT)
+
+    def process_race(self, entries: list[RaceEntry]) -> None:
+        """Update constructor ratings from a single race.
+
+        Args:
+            entries: All driver entries for one race (any order).  Entries
+                with ``dnf_category="mechanical"`` are excluded when
+                ``config.exclude_mechanical_dnf`` is True.
+        """
+        filtered = self._filter_entries(entries)
+        ordered = order_race_entries(filtered)
+        if len(ordered) < 2:
+            return
+
+        # Assign each driver a 1-based rank by their index in the ordered list
+        driver_rank: dict[str, float] = {e["driver_id"]: float(i + 1) for i, e in enumerate(ordered)}
+
+        # Group by team and compute average rank
+        team_ranks: dict[str, list[float]] = {}
+        for e in ordered:
+            team_ranks.setdefault(e["team"], []).append(driver_rank[e["driver_id"]])
+
+        if len(team_ranks) < 2:
+            return
+
+        # Sort constructors by average rank ascending (lower = better)
+        constructor_order: list[str] = sorted(team_ranks, key=lambda t: sum(team_ranks[t]) / len(team_ranks[t]))
+
+        # Ensure all constructors are initialized
+        for team in constructor_order:
+            self.get_rating(team)
+
+        # Apply between-race decay
+        for team in constructor_order:
+            self.ratings[team] *= self.config.phi_race
+
+        # Sequential elimination: identical algorithm to EndureElo
+        remaining = list(constructor_order)  # best-performing constructor first
+
+        for _ in range(len(remaining) - 1):
+            eliminated = remaining[-1]
+
+            neg_ratings = np.array([-self.ratings[t] for t in remaining])
+            neg_ratings_shifted = neg_ratings - neg_ratings.max()
+            exp_neg = np.exp(neg_ratings_shifted)
+            elim_probs = exp_neg / exp_neg.sum()
+            survive_probs = 1.0 - elim_probs
+
+            # K-factor update
+            for idx, team in enumerate(remaining):
+                p_s = survive_probs[idx]
+                k_inv = 1.0 / self.k_factors[team] + p_s * (1.0 - p_s)
+                self.k_factors[team] = max(self.config.k_min, min(1.0 / k_inv, self.config.k_max))
+
+            # Rating update
+            for idx, team in enumerate(remaining):
+                survived = 1.0 if team != eliminated else 0.0
+                self.ratings[team] += self.k_factors[team] * (survived - survive_probs[idx])
+
+            remaining.pop()
+
+    def predict_win_probabilities(self, constructor_ids: list[str]) -> np.ndarray:
+        """Compute win probability for each constructor using inclusion-exclusion.
+
+        Args:
+            constructor_ids: List of constructor (team) names.
+
+        Returns:
+            Array of probabilities summing to 1.0, same order as constructor_ids.
+        """
+        n = len(constructor_ids)
+        if n == 0:
+            return np.array([])
+        if n == 1:
+            return np.array([1.0])
+
+        lambdas = np.array([np.exp(-self.get_rating(t)) for t in constructor_ids])
+        probs = _inclusion_exclusion(lambdas)
+        probs = np.clip(probs, 0.0, 1.0)
+        total = probs.sum()
+        if total > 0:
+            probs /= total
+        return probs
+
+
+CONSTRUCTOR_ELO_DEFAULT = ENDURE_ELO_DEFAULT
+
+__all__ = ["ConstructorElo", "CONSTRUCTOR_ELO_DEFAULT"]

--- a/packages/pitlane-elo/src/pitlane_elo/ratings/constructor_elo.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings/constructor_elo.py
@@ -141,5 +141,4 @@ class ConstructorElo(RatingModel):
         return probs
 
 
-
 __all__ = ["ConstructorElo", "CONSTRUCTOR_ELO_DEFAULT"]

--- a/packages/pitlane-elo/src/pitlane_elo/ratings/constructor_elo.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings/constructor_elo.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import numpy as np
 
-from pitlane_elo.config import ENDURE_ELO_DEFAULT, EloConfig
+from pitlane_elo.config import CONSTRUCTOR_ELO_DEFAULT, EloConfig
 from pitlane_elo.data import RaceEntry, order_race_entries
 from pitlane_elo.ratings.base import RatingModel
 from pitlane_elo.ratings.endure_elo import _inclusion_exclusion
@@ -42,7 +42,7 @@ class ConstructorElo(RatingModel):
     """
 
     def __init__(self, config: EloConfig | None = None) -> None:
-        super().__init__(config or ENDURE_ELO_DEFAULT)
+        super().__init__(config or CONSTRUCTOR_ELO_DEFAULT)
 
     def process_race(self, entries: list[RaceEntry]) -> None:
         """Update constructor ratings from a single race.
@@ -141,6 +141,5 @@ class ConstructorElo(RatingModel):
         return probs
 
 
-CONSTRUCTOR_ELO_DEFAULT = ENDURE_ELO_DEFAULT
 
 __all__ = ["ConstructorElo", "CONSTRUCTOR_ELO_DEFAULT"]

--- a/packages/pitlane-elo/src/pitlane_elo/ratings/constructor_elo.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings/constructor_elo.py
@@ -1,9 +1,10 @@
 """Constructor endure-Elo: Powell's sequential knock-out model applied to constructors.
 
-Each constructor's per-race "performance position" is derived from the average
-implied finishing rank of its drivers. DNFs without finish_position are ranked
-by laps_completed (consistent with order_race_entries). If only one driver has
-a valid entry, that driver's implied rank is used directly.
+Each constructor's per-race performance is measured by the sum of F1 championship
+points earned by its drivers (using the current 25-18-15-12-10-8-6-4-2-1 scale).
+Constructors are ordered by descending points total — the same criterion used
+in the actual F1 constructor standings. DNFs and positions outside the top 10
+contribute 0 points, consistent with F1 rules.
 
 The sequential elimination algorithm is identical to EndureElo but operates
 over constructor entities rather than individual drivers.
@@ -18,6 +19,15 @@ from pitlane_elo.data import RaceEntry, order_race_entries
 from pitlane_elo.ratings.base import RatingModel
 from pitlane_elo.ratings.endure_elo import _inclusion_exclusion
 
+# F1 championship points by finishing position (current scale, applied universally).
+# Positions outside the top 10 and DNFs contribute 0 points.
+_F1_POINTS: dict[int, int] = {1: 25, 2: 18, 3: 15, 4: 12, 5: 10, 6: 8, 7: 6, 8: 4, 9: 2, 10: 1}
+
+
+def _race_points(rank: int) -> int:
+    """Return F1 championship points for a given 1-based implied finishing rank."""
+    return _F1_POINTS.get(rank, 0)
+
 
 class ConstructorElo(RatingModel):
     """Endure-Elo applied to F1 constructors.
@@ -25,10 +35,10 @@ class ConstructorElo(RatingModel):
     Team names are used as keys in the ``ratings`` and ``k_factors`` dicts
     (matching the ``team`` field on :class:`~pitlane_elo.data.RaceEntry`).
 
-    Per-race constructor position is computed as the average 1-based rank of
-    the constructor's drivers in the full field ordering produced by
-    :func:`~pitlane_elo.data.order_race_entries`.  This handles DNFs
-    consistently without special-casing ``None`` finish positions.
+    Constructors are ordered each race by their total F1 championship points
+    (sum across both drivers), matching the criterion used in the actual F1
+    constructor standings. This correctly ranks 1st+4th (37 pts) above
+    2nd+3rd (33 pts), and 2nd+3rd above 1st+20th (25 pts).
     """
 
     def __init__(self, config: EloConfig | None = None) -> None:
@@ -47,19 +57,30 @@ class ConstructorElo(RatingModel):
         if len(ordered) < 2:
             return
 
-        # Assign each driver a 1-based rank by their index in the ordered list
-        driver_rank: dict[str, float] = {e["driver_id"]: float(i + 1) for i, e in enumerate(ordered)}
+        # Assign each driver a 1-based rank and F1 championship points.
+        driver_rank: dict[str, int] = {e["driver_id"]: i + 1 for i, e in enumerate(ordered)}
+        driver_points: dict[str, int] = {d: _race_points(r) for d, r in driver_rank.items()}
 
-        # Group by team and compute average rank
-        team_ranks: dict[str, list[float]] = {}
+        # Group by team: accumulate total points and track best (lowest) rank.
+        team_points: dict[str, int] = {}
+        team_best_rank: dict[str, int] = {}
         for e in ordered:
-            team_ranks.setdefault(e["team"], []).append(driver_rank[e["driver_id"]])
+            did = e["driver_id"]
+            team = e["team"]
+            team_points[team] = team_points.get(team, 0) + driver_points[did]
+            team_best_rank[team] = min(team_best_rank.get(team, 999), driver_rank[did])
 
-        if len(team_ranks) < 2:
+        if len(team_points) < 2:
             return
 
-        # Sort constructors by average rank ascending (lower = better)
-        constructor_order: list[str] = sorted(team_ranks, key=lambda t: sum(team_ranks[t]) / len(team_ranks[t]))
+        # Sort constructors best-first.
+        # Primary key: descending F1 points (correctly orders top-10 finishers).
+        # Tiebreaker: ascending best finishing rank (resolves ties in the 0-point
+        # zone, P11 and below, where all teams would otherwise score 0).
+        constructor_order: list[str] = sorted(
+            team_points,
+            key=lambda t: (-team_points[t], team_best_rank[t]),
+        )
 
         # Ensure all constructors are initialized
         for team in constructor_order:
@@ -94,22 +115,24 @@ class ConstructorElo(RatingModel):
 
             remaining.pop()
 
-    def predict_win_probabilities(self, constructor_ids: list[str]) -> np.ndarray:
+    def predict_win_probabilities(self, driver_ids: list[str]) -> np.ndarray:
         """Compute win probability for each constructor using inclusion-exclusion.
 
         Args:
-            constructor_ids: List of constructor (team) names.
+            driver_ids: List of constructor (team) names. The parameter name
+                matches the base class interface; for ConstructorElo the values
+                are team name strings rather than driver ID slugs.
 
         Returns:
-            Array of probabilities summing to 1.0, same order as constructor_ids.
+            Array of probabilities summing to 1.0, same order as driver_ids.
         """
-        n = len(constructor_ids)
+        n = len(driver_ids)
         if n == 0:
             return np.array([])
         if n == 1:
             return np.array([1.0])
 
-        lambdas = np.array([np.exp(-self.get_rating(t)) for t in constructor_ids])
+        lambdas = np.array([np.exp(-self.get_rating(t)) for t in driver_ids])
         probs = _inclusion_exclusion(lambdas)
         probs = np.clip(probs, 0.0, 1.0)
         total = probs.sum()

--- a/packages/pitlane-elo/src/pitlane_elo/separation/__init__.py
+++ b/packages/pitlane-elo/src/pitlane_elo/separation/__init__.py
@@ -1,7 +1,12 @@
+from pitlane_elo.separation.alpha_estimation import estimate_alpha
 from pitlane_elo.separation.car_rating import CarRating, compute_rc_range, compute_session_rc
+from pitlane_elo.separation.decompose import TeammateData, TeammateNormaliser
 
 __all__ = [
     "CarRating",
     "compute_rc_range",
     "compute_session_rc",
+    "TeammateData",
+    "TeammateNormaliser",
+    "estimate_alpha",
 ]

--- a/packages/pitlane-elo/src/pitlane_elo/separation/alpha_estimation.py
+++ b/packages/pitlane-elo/src/pitlane_elo/separation/alpha_estimation.py
@@ -1,39 +1,23 @@
 """Empirical estimation of the constructor-adjustment weight alpha.
 
-Implements a grid search to find the alpha that maximises the log-likelihood
-of race winners when driver ratings are adjusted by:
+Implements OLS variance decomposition (van Kesteren & Bergkamp 2023, §7.3):
 
-    adjusted_i = R_driver_i - alpha * R_constructor_i
+    alpha = Cov(driver_ratings, constructor_ratings) / Var(constructor_ratings)
 
-where R_constructor is produced by a parallel ConstructorElo track.
-
-NOTE — Circularity: ConstructorElo is trained on raw driver finish positions,
-not on alpha-adjusted positions. This means the two models are not jointly
-optimised. The estimated alpha will be a first-order approximation; the
-literature value (van Kesteren & Bergkamp 2023) is ~7.3.  Joint optimisation
-(alternating updates until convergence) is a future refinement.
+This measures the fraction of a driver's ELO explained by their car's ELO.
+Ratings are recorded **before** each race update so they are out-of-sample
+with respect to that race.
 """
 
 from __future__ import annotations
 
-from collections.abc import Callable
 from pathlib import Path
-from typing import TypedDict
 
 import numpy as np
 
 from pitlane_elo.data import get_race_entries_range, group_entries_by_race
 from pitlane_elo.ratings.constructor_elo import ConstructorElo
-from pitlane_elo.ratings.endure_elo import EndureElo, _inclusion_exclusion
-
-
-class _RaceObs(TypedDict):
-    """Per-driver observation for one race, used in grid search scoring."""
-
-    driver_id: str
-    driver_rating: float
-    constructor_rating: float
-    is_winner: bool
+from pitlane_elo.ratings.endure_elo import EndureElo
 
 
 def estimate_alpha(
@@ -41,52 +25,44 @@ def estimate_alpha(
     end_year: int,
     *,
     db_path: Path | None = None,
-    alpha_bounds: tuple[float, float] = (0.0, 15.0),
-    n_steps: int = 30,
-    on_step: Callable[[int, int, float, float, float], None] | None = None,
 ) -> float:
-    """Estimate the constructor-adjustment weight alpha via grid search.
+    """Estimate the constructor-adjustment weight alpha via OLS variance decomposition.
 
     Runs :class:`~pitlane_elo.ratings.endure_elo.EndureElo` and
     :class:`~pitlane_elo.ratings.constructor_elo.ConstructorElo` in parallel
-    over ``[start_year, end_year]``.  After each race both models are updated
-    and per-driver ``(driver_rating, constructor_rating)`` pairs are recorded.
+    over ``[start_year, end_year]``.  Before each race, the current pre-race
+    ``(driver_rating, constructor_rating)`` pair is recorded for each entry.
 
-    Alpha is then fit by a uniform grid search over ``alpha_bounds`` with
-    ``n_steps`` candidate values.  For each candidate the adjusted driver
-    ratings ``R_driver - alpha * R_constructor`` are passed through the
-    inclusion-exclusion win probability formula and the sum of
-    ``log P(winner)`` over all races is computed.  The alpha with the
-    highest log-likelihood is returned.
+    Alpha is then estimated as the OLS slope of driver ratings on constructor
+    ratings::
 
-    Returns ``alpha_bounds[0]`` if there is no data for the requested range.
+        alpha = Cov(driver_ratings, constructor_ratings) / Var(constructor_ratings)
+
+    Returns ``0.0`` if there is no data for the requested range or if all
+    constructor ratings are identical (zero variance, OLS undefined).
 
     Args:
         start_year: First season to process (used for warm-up and estimation).
         end_year: Last season (inclusive).
         db_path: Override the database path.
-        alpha_bounds: ``(lo, hi)`` range for the grid search.
-        n_steps: Number of evenly-spaced candidate alpha values.
-        on_step: Optional callback invoked after each grid-search step with
-            ``(step, total, alpha, log_likelihood, best_ll_so_far)``.
 
     Returns:
-        Estimated alpha value in ``[alpha_bounds[0], alpha_bounds[1]]``.
+        Estimated alpha value.
     """
     all_entries = get_race_entries_range(start_year, end_year, db_path=db_path)
     if not all_entries:
-        return alpha_bounds[0]
+        return 0.0
 
     filtered = [e for e in all_entries if e["session_type"] == "R"]
     if not filtered:
-        return alpha_bounds[0]
+        return 0.0
 
     races = group_entries_by_race(filtered)
     driver_model = EndureElo()
     constructor_model = ConstructorElo()
 
-    # Per-race observation lists for the grid search
-    race_observations: list[list[_RaceObs]] = []
+    driver_ratings: list[float] = []
+    constructor_ratings: list[float] = []
 
     current_year: int | None = None
 
@@ -99,65 +75,26 @@ def estimate_alpha(
             constructor_model.apply_season_decay(year)
         current_year = year
 
-        # Update both models
+        # Record BEFORE update (out-of-sample)
+        for e in race_entries:
+            driver_ratings.append(driver_model.get_rating(e["driver_id"]))
+            constructor_ratings.append(constructor_model.get_rating(e["team"]))
+
+        # Then update both models
         driver_model.process_race(race_entries)
         constructor_model.process_race(race_entries)
 
-        # Determine winner (first entry in finishing order)
-        ordered_ids = [e["driver_id"] for e in race_entries]
-        winner_id = ordered_ids[0]
+    if len(driver_ratings) < 2:
+        return 0.0
 
-        obs: list[_RaceObs] = []
-        for e in race_entries:
-            driver_id = e["driver_id"]
-            team = e["team"]
-            # Both models initialise unseen entities on first get_rating call
-            obs.append(
-                _RaceObs(
-                    driver_id=driver_id,
-                    driver_rating=driver_model.get_rating(driver_id),
-                    constructor_rating=constructor_model.get_rating(team),
-                    is_winner=(driver_id == winner_id),
-                )
-            )
-        race_observations.append(obs)
+    x = np.array(constructor_ratings)
+    y = np.array(driver_ratings)
 
-    if not race_observations:
-        return alpha_bounds[0]
+    if np.var(x) < 1e-12:
+        # All constructor ratings identical — OLS undefined, return safe default
+        return 0.0
 
-    # Grid search over alpha candidates
-    candidates = np.linspace(alpha_bounds[0], alpha_bounds[1], max(n_steps, 1))
-    best_alpha = candidates[0]
-    best_ll = float("-inf")
-    total_steps = len(candidates)
-
-    for step, alpha in enumerate(candidates, 1):
-        total_ll = 0.0
-        for race_obs in race_observations:
-            if not race_obs:
-                continue
-
-            adjusted = np.array([o["driver_rating"] - alpha * o["constructor_rating"] for o in race_obs])
-            lambdas = np.exp(-adjusted)
-            probs = _inclusion_exclusion(lambdas)
-            probs = np.clip(probs, 1e-15, 1.0)
-            total = probs.sum()
-            if total > 0:
-                probs = probs / total
-
-            winner_idx = next((i for i, o in enumerate(race_obs) if o["is_winner"]), None)
-            if winner_idx is None:
-                continue
-            total_ll += float(np.log(max(probs[winner_idx], 1e-15)))
-
-        if total_ll > best_ll:
-            best_ll = total_ll
-            best_alpha = float(alpha)
-
-        if on_step is not None:
-            on_step(step, total_steps, float(alpha), total_ll, best_ll)
-
-    return best_alpha
+    return float(np.polyfit(x, y, 1)[0])
 
 
 __all__ = ["estimate_alpha"]

--- a/packages/pitlane-elo/src/pitlane_elo/separation/alpha_estimation.py
+++ b/packages/pitlane-elo/src/pitlane_elo/separation/alpha_estimation.py
@@ -16,6 +16,7 @@ literature value (van Kesteren & Bergkamp 2023) is ~7.3.  Joint optimisation
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
 from typing import TypedDict
 
@@ -42,6 +43,7 @@ def estimate_alpha(
     db_path: Path | None = None,
     alpha_bounds: tuple[float, float] = (0.0, 15.0),
     n_steps: int = 30,
+    on_step: Callable[[int, int, float, float, float], None] | None = None,
 ) -> float:
     """Estimate the constructor-adjustment weight alpha via grid search.
 
@@ -65,6 +67,8 @@ def estimate_alpha(
         db_path: Override the database path.
         alpha_bounds: ``(lo, hi)`` range for the grid search.
         n_steps: Number of evenly-spaced candidate alpha values.
+        on_step: Optional callback invoked after each grid-search step with
+            ``(step, total, alpha, log_likelihood, best_ll_so_far)``.
 
     Returns:
         Estimated alpha value in ``[alpha_bounds[0], alpha_bounds[1]]``.
@@ -125,8 +129,9 @@ def estimate_alpha(
     candidates = np.linspace(alpha_bounds[0], alpha_bounds[1], max(n_steps, 1))
     best_alpha = candidates[0]
     best_ll = float("-inf")
+    total_steps = len(candidates)
 
-    for alpha in candidates:
+    for step, alpha in enumerate(candidates, 1):
         total_ll = 0.0
         for race_obs in race_observations:
             if not race_obs:
@@ -148,6 +153,9 @@ def estimate_alpha(
         if total_ll > best_ll:
             best_ll = total_ll
             best_alpha = float(alpha)
+
+        if on_step is not None:
+            on_step(step, total_steps, float(alpha), total_ll, best_ll)
 
     return best_alpha
 

--- a/packages/pitlane-elo/src/pitlane_elo/separation/alpha_estimation.py
+++ b/packages/pitlane-elo/src/pitlane_elo/separation/alpha_estimation.py
@@ -1,0 +1,155 @@
+"""Empirical estimation of the constructor-adjustment weight alpha.
+
+Implements a grid search to find the alpha that maximises the log-likelihood
+of race winners when driver ratings are adjusted by:
+
+    adjusted_i = R_driver_i - alpha * R_constructor_i
+
+where R_constructor is produced by a parallel ConstructorElo track.
+
+NOTE — Circularity: ConstructorElo is trained on raw driver finish positions,
+not on alpha-adjusted positions. This means the two models are not jointly
+optimised. The estimated alpha will be a first-order approximation; the
+literature value (van Kesteren & Bergkamp 2023) is ~7.3.  Joint optimisation
+(alternating updates until convergence) is a future refinement.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import TypedDict
+
+import numpy as np
+
+from pitlane_elo.data import get_race_entries_range, group_entries_by_race
+from pitlane_elo.ratings.constructor_elo import ConstructorElo
+from pitlane_elo.ratings.endure_elo import EndureElo, _inclusion_exclusion
+
+
+class _RaceObs(TypedDict):
+    """Per-driver observation for one race, used in grid search scoring."""
+
+    driver_id: str
+    driver_rating: float
+    constructor_rating: float
+    is_winner: bool
+
+
+def estimate_alpha(
+    start_year: int,
+    end_year: int,
+    *,
+    db_path: Path | None = None,
+    alpha_bounds: tuple[float, float] = (0.0, 15.0),
+    n_steps: int = 30,
+) -> float:
+    """Estimate the constructor-adjustment weight alpha via grid search.
+
+    Runs :class:`~pitlane_elo.ratings.endure_elo.EndureElo` and
+    :class:`~pitlane_elo.ratings.constructor_elo.ConstructorElo` in parallel
+    over ``[start_year, end_year]``.  After each race both models are updated
+    and per-driver ``(driver_rating, constructor_rating)`` pairs are recorded.
+
+    Alpha is then fit by a uniform grid search over ``alpha_bounds`` with
+    ``n_steps`` candidate values.  For each candidate the adjusted driver
+    ratings ``R_driver - alpha * R_constructor`` are passed through the
+    inclusion-exclusion win probability formula and the sum of
+    ``log P(winner)`` over all races is computed.  The alpha with the
+    highest log-likelihood is returned.
+
+    Returns ``alpha_bounds[0]`` if there is no data for the requested range.
+
+    Args:
+        start_year: First season to process (used for warm-up and estimation).
+        end_year: Last season (inclusive).
+        db_path: Override the database path.
+        alpha_bounds: ``(lo, hi)`` range for the grid search.
+        n_steps: Number of evenly-spaced candidate alpha values.
+
+    Returns:
+        Estimated alpha value in ``[alpha_bounds[0], alpha_bounds[1]]``.
+    """
+    all_entries = get_race_entries_range(start_year, end_year, db_path=db_path)
+    if not all_entries:
+        return alpha_bounds[0]
+
+    filtered = [e for e in all_entries if e["session_type"] == "R"]
+    if not filtered:
+        return alpha_bounds[0]
+
+    races = group_entries_by_race(filtered)
+    driver_model = EndureElo()
+    constructor_model = ConstructorElo()
+
+    # Per-race observation lists for the grid search
+    race_observations: list[list[_RaceObs]] = []
+
+    current_year: int | None = None
+
+    for race_entries in races:
+        year = race_entries[0]["year"]
+
+        # Season boundary: apply decay to both models
+        if current_year is not None and year != current_year:
+            driver_model.apply_season_decay(year)
+            constructor_model.apply_season_decay(year)
+        current_year = year
+
+        # Update both models
+        driver_model.process_race(race_entries)
+        constructor_model.process_race(race_entries)
+
+        # Determine winner (first entry in finishing order)
+        ordered_ids = [e["driver_id"] for e in race_entries]
+        winner_id = ordered_ids[0]
+
+        obs: list[_RaceObs] = []
+        for e in race_entries:
+            driver_id = e["driver_id"]
+            team = e["team"]
+            # Both models initialise unseen entities on first get_rating call
+            obs.append(
+                _RaceObs(
+                    driver_id=driver_id,
+                    driver_rating=driver_model.get_rating(driver_id),
+                    constructor_rating=constructor_model.get_rating(team),
+                    is_winner=(driver_id == winner_id),
+                )
+            )
+        race_observations.append(obs)
+
+    if not race_observations:
+        return alpha_bounds[0]
+
+    # Grid search over alpha candidates
+    candidates = np.linspace(alpha_bounds[0], alpha_bounds[1], max(n_steps, 1))
+    best_alpha = candidates[0]
+    best_ll = float("-inf")
+
+    for alpha in candidates:
+        total_ll = 0.0
+        for race_obs in race_observations:
+            if not race_obs:
+                continue
+
+            adjusted = np.array([o["driver_rating"] - alpha * o["constructor_rating"] for o in race_obs])
+            lambdas = np.exp(-adjusted)
+            probs = _inclusion_exclusion(lambdas)
+            probs = np.clip(probs, 1e-15, 1.0)
+            total = probs.sum()
+            if total > 0:
+                probs = probs / total
+
+            winner_idx = next((i for i, o in enumerate(race_obs) if o["is_winner"]), None)
+            if winner_idx is None:
+                continue
+            total_ll += float(np.log(max(probs[winner_idx], 1e-15)))
+
+        if total_ll > best_ll:
+            best_ll = total_ll
+            best_alpha = float(alpha)
+
+    return best_alpha
+
+
+__all__ = ["estimate_alpha"]

--- a/packages/pitlane-elo/src/pitlane_elo/separation/alpha_estimation.py
+++ b/packages/pitlane-elo/src/pitlane_elo/separation/alpha_estimation.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
+from scipy import stats
 
 from pitlane_elo.data import get_race_entries_range, group_entries_by_race
 from pitlane_elo.ratings.constructor_elo import ConstructorElo
@@ -94,7 +95,7 @@ def estimate_alpha(
         # All constructor ratings identical — OLS undefined, return safe default
         return 0.0
 
-    return float(np.polyfit(x, y, 1)[0])
+    return float(stats.linregress(x, y).slope)
 
 
 __all__ = ["estimate_alpha"]

--- a/packages/pitlane-elo/src/pitlane_elo/separation/decompose.py
+++ b/packages/pitlane-elo/src/pitlane_elo/separation/decompose.py
@@ -10,3 +10,105 @@ variance is explained by the constructor, ~12% by driver skill.
 """
 
 from __future__ import annotations
+
+from typing import TypedDict
+
+from pitlane_elo.data import RaceEntry
+
+
+class TeammateData(TypedDict):
+    """Within-team rating delta for a single driver in a single race."""
+
+    year: int
+    round: int
+    driver_id: str
+    teammate_id: str
+    driver_rating: float
+    teammate_rating: float
+    delta: float  # driver_rating - teammate_rating; positive = driver is higher rated
+
+
+class TeammateNormaliser:
+    """Accumulates within-team rating deltas across a driver's career.
+
+    Call :meth:`record` immediately *after* the driver ELO model has processed
+    each race so that ``ratings`` reflect post-update values.
+
+    Both directions are stored (A→B and B→A), making per-driver queries
+    straightforward without joining.
+    """
+
+    def __init__(self) -> None:
+        self.history: dict[str, list[TeammateData]] = {}
+
+    def record(
+        self,
+        entries: list[RaceEntry],
+        ratings: dict[str, float],
+    ) -> list[TeammateData]:
+        """Record within-team rating deltas after a race has been processed.
+
+        Args:
+            entries: All driver entries for the race (any order).
+            ratings: Current driver ratings from the ELO model (post-update).
+
+        Returns:
+            List of :class:`TeammateData` recorded for this race.
+            Empty if no team has two valid finishers present in ``ratings``.
+        """
+        if not entries:
+            return []
+
+        year = entries[0]["year"]
+        rnd = entries[0]["round"]
+
+        # Collect valid finishers that also appear in ratings
+        valid: list[RaceEntry] = [
+            e for e in entries if e.get("finish_position") is not None and e["driver_id"] in ratings
+        ]
+
+        # Group by team
+        by_team: dict[str, list[RaceEntry]] = {}
+        for e in valid:
+            by_team.setdefault(e["team"], []).append(e)
+
+        new_records: list[TeammateData] = []
+
+        for team_entries in by_team.values():
+            if len(team_entries) < 2:
+                continue
+
+            # For 3+-car teams (rare, pre-1980): use the two with lowest finish_position
+            sorted_entries = sorted(team_entries, key=lambda e: e["finish_position"])  # type: ignore[arg-type]
+            a, b = sorted_entries[0], sorted_entries[1]
+
+            r_a = ratings[a["driver_id"]]
+            r_b = ratings[b["driver_id"]]
+
+            record_a = TeammateData(
+                year=year,
+                round=rnd,
+                driver_id=a["driver_id"],
+                teammate_id=b["driver_id"],
+                driver_rating=r_a,
+                teammate_rating=r_b,
+                delta=r_a - r_b,
+            )
+            record_b = TeammateData(
+                year=year,
+                round=rnd,
+                driver_id=b["driver_id"],
+                teammate_id=a["driver_id"],
+                driver_rating=r_b,
+                teammate_rating=r_a,
+                delta=r_b - r_a,
+            )
+
+            self.history.setdefault(a["driver_id"], []).append(record_a)
+            self.history.setdefault(b["driver_id"], []).append(record_b)
+            new_records.extend([record_a, record_b])
+
+        return new_records
+
+
+__all__ = ["TeammateData", "TeammateNormaliser"]

--- a/packages/pitlane-elo/tests/ratings/test_constructor_elo.py
+++ b/packages/pitlane-elo/tests/ratings/test_constructor_elo.py
@@ -144,9 +144,9 @@ class TestConstructorElo:
             _make("X8", "Filler4", 8),
             _make("X9", "Filler5", 9),
             _make("X10", "Filler5", 10),
-            _make("A1", "TeamA", 11),   # 0 pts, best rank 11
+            _make("A1", "TeamA", 11),  # 0 pts, best rank 11
             _make("A2", "TeamA", 13),
-            _make("B1", "TeamB", 12),   # 0 pts, best rank 12
+            _make("B1", "TeamB", 12),  # 0 pts, best rank 12
             _make("B2", "TeamB", 14),
         ]
         for _ in range(20):

--- a/packages/pitlane-elo/tests/ratings/test_constructor_elo.py
+++ b/packages/pitlane-elo/tests/ratings/test_constructor_elo.py
@@ -1,0 +1,172 @@
+"""Tests for pitlane_elo.ratings.constructor_elo."""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from pitlane_elo.config import EloConfig
+from pitlane_elo.data import RaceEntry
+from pitlane_elo.ratings.constructor_elo import ConstructorElo
+
+from tests.conftest import make_race_entry
+
+
+# ---------------------------------------------------------------------------
+# Helper: make_race_entry with a real team name
+# ---------------------------------------------------------------------------
+
+
+def _make(driver_id: str, team: str, finish: int | None, laps: int = 57) -> RaceEntry:
+    e = make_race_entry(driver_id, finish, laps=laps)
+    return {**e, "team": team}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestConstructorElo:
+    def test_instantiation(self) -> None:
+        model = ConstructorElo()
+        assert model.config is not None
+        assert isinstance(model.ratings, dict)
+
+    def test_winner_rating_increases(self) -> None:
+        """After one race the winning constructor's rating should rise."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", 2),
+            _make("B1", "TeamB", 3),
+            _make("B2", "TeamB", 4),
+            _make("C1", "TeamC", 5),
+            _make("C2", "TeamC", 6),
+        ]
+        model.process_race(entries)
+        assert model.ratings["TeamA"] > 0.0
+        assert model.ratings["TeamC"] < 0.0
+
+    def test_repeated_races_diverge_ratings(self) -> None:
+        """After many races where TeamA dominates, ratings diverge in order."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", 2),
+            _make("B1", "TeamB", 3),
+            _make("B2", "TeamB", 4),
+            _make("C1", "TeamC", 5),
+            _make("C2", "TeamC", 6),
+        ]
+        for _ in range(20):
+            model.process_race(entries)
+        assert model.ratings["TeamA"] > model.ratings["TeamB"] > model.ratings["TeamC"]
+
+    def test_probabilities_sum_to_one(self) -> None:
+        """predict_win_probabilities should return values summing to 1.0."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", 2),
+            _make("B1", "TeamB", 3),
+            _make("B2", "TeamB", 4),
+        ]
+        for _ in range(5):
+            model.process_race(entries)
+
+        probs = model.predict_win_probabilities(["TeamA", "TeamB"])
+        assert probs.shape == (2,)
+        assert abs(probs.sum() - 1.0) < 1e-10
+
+    def test_higher_rated_constructor_has_higher_win_prob(self) -> None:
+        """After training, the dominant constructor should have higher win prob."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", 2),
+            _make("B1", "TeamB", 3),
+            _make("B2", "TeamB", 4),
+        ]
+        for _ in range(10):
+            model.process_race(entries)
+
+        probs = model.predict_win_probabilities(["TeamA", "TeamB"])
+        assert probs[0] > probs[1]
+
+    def test_solo_finisher_uses_that_position(self) -> None:
+        """If one driver DNFs (no finish_position), the team still participates."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", None, laps=10),  # DNF
+            _make("B1", "TeamB", 2),
+            _make("B2", "TeamB", 3),
+        ]
+        # Should process without error
+        model.process_race(entries)
+        assert "TeamA" in model.ratings
+        assert "TeamB" in model.ratings
+
+    def test_both_dnf_team_ranked_last(self) -> None:
+        """A team where both drivers DNF is ranked after all finishers."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", 2),
+            _make("B1", "TeamB", None, laps=5),
+            _make("B2", "TeamB", None, laps=3),
+        ]
+        model.process_race(entries)
+        # TeamA (finishers) should have higher rating than TeamB (both DNF)
+        assert model.ratings["TeamA"] > model.ratings["TeamB"]
+
+    def test_k_factor_decreases_with_more_data(self) -> None:
+        """K-factor should decrease (Glicko-style) as more data accumulates."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", 2),
+            _make("B1", "TeamB", 3),
+            _make("B2", "TeamB", 4),
+        ]
+        model.process_race(entries)
+        k_after_1 = model.k_factors["TeamA"]
+        for _ in range(19):
+            model.process_race(entries)
+        k_after_20 = model.k_factors["TeamA"]
+        assert k_after_20 < k_after_1
+
+    def test_season_decay_reduces_ratings(self) -> None:
+        """apply_season_decay (inherited) should reduce ratings toward zero."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", 2),
+            _make("B1", "TeamB", 3),
+            _make("B2", "TeamB", 4),
+        ]
+        for _ in range(5):
+            model.process_race(entries)
+
+        rating_before = model.ratings["TeamA"]
+        model.apply_season_decay(2025)
+        rating_after = model.ratings["TeamA"]
+
+        assert abs(rating_after) < abs(rating_before)
+
+    def test_too_few_constructors_skipped(self) -> None:
+        """A race with only one constructor produces no rating update."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("A2", "TeamA", 2),
+        ]
+        model.process_race(entries)
+        # No ratings should be populated (single-constructor race is skipped)
+        assert model.ratings == {}
+
+    def test_custom_config(self) -> None:
+        """ConstructorElo accepts a custom EloConfig."""
+        config = EloConfig(name="test-constructor", k_max=0.1)
+        model = ConstructorElo(config)
+        assert model.config.k_max == 0.1

--- a/packages/pitlane-elo/tests/ratings/test_constructor_elo.py
+++ b/packages/pitlane-elo/tests/ratings/test_constructor_elo.py
@@ -93,6 +93,69 @@ class TestConstructorElo:
         probs = model.predict_win_probabilities(["TeamA", "TeamB"])
         assert probs[0] > probs[1]
 
+    def test_f1_points_ordering_1st_4th_beats_2nd_3rd(self) -> None:
+        """1st+4th (37 pts) should beat 2nd+3rd (33 pts) — average rank ties them."""
+        model = ConstructorElo()
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("B1", "TeamB", 2),
+            _make("B2", "TeamB", 3),
+            _make("A2", "TeamA", 4),
+        ]
+        for _ in range(20):
+            model.process_race(entries)
+        assert model.ratings["TeamA"] > model.ratings["TeamB"]
+
+    def test_f1_points_ordering_2nd_3rd_beats_1st_last(self) -> None:
+        """2nd+3rd (33 pts) should beat 1st+20th (25 pts) — best-driver ordering gets this wrong."""
+        model = ConstructorElo()
+        # 6-car field: TeamA gets P1+P6, TeamB gets P2+P3.
+        # F1 points: A=25+8=33, B=18+15=33. Tie — use a larger gap.
+        # TeamA gets P1+P6 (25+8=33), TeamB gets P2+P3 (18+15=33). Still a tie.
+        # Use P1+last vs P2+P3 with enough cars to push A's second driver to 0 pts.
+        # 12-car field: TeamA P1+P12=25+0=25, TeamB P2+P3=18+15=33.
+        entries = [
+            _make("A1", "TeamA", 1),
+            _make("B1", "TeamB", 2),
+            _make("B2", "TeamB", 3),
+            _make("C1", "TeamC", 4),
+            _make("C2", "TeamC", 5),
+            _make("D1", "TeamD", 6),
+            _make("D2", "TeamD", 7),
+            _make("E1", "TeamE", 8),
+            _make("E2", "TeamE", 9),
+            _make("F1", "TeamF", 10),
+            _make("F2", "TeamF", 11),
+            _make("A2", "TeamA", 12),
+        ]
+        for _ in range(20):
+            model.process_race(entries)
+        # TeamB (2nd+3rd, 33 pts) should outrank TeamA (1st+12th, 25 pts)
+        assert model.ratings["TeamB"] > model.ratings["TeamA"]
+
+    def test_zero_points_zone_ordered_by_best_rank(self) -> None:
+        """P11+P13 should beat P12+P14 even though both score 0 championship points."""
+        model = ConstructorElo()
+        entries = [
+            _make("X1", "Filler1", 1),
+            _make("X2", "Filler1", 2),
+            _make("X3", "Filler2", 3),
+            _make("X4", "Filler2", 4),
+            _make("X5", "Filler3", 5),
+            _make("X6", "Filler3", 6),
+            _make("X7", "Filler4", 7),
+            _make("X8", "Filler4", 8),
+            _make("X9", "Filler5", 9),
+            _make("X10", "Filler5", 10),
+            _make("A1", "TeamA", 11),   # 0 pts, best rank 11
+            _make("A2", "TeamA", 13),
+            _make("B1", "TeamB", 12),   # 0 pts, best rank 12
+            _make("B2", "TeamB", 14),
+        ]
+        for _ in range(20):
+            model.process_race(entries)
+        assert model.ratings["TeamA"] > model.ratings["TeamB"]
+
     def test_solo_finisher_uses_that_position(self) -> None:
         """If one driver DNFs (no finish_position), the team still participates."""
         model = ConstructorElo()

--- a/packages/pitlane-elo/tests/ratings/test_constructor_elo.py
+++ b/packages/pitlane-elo/tests/ratings/test_constructor_elo.py
@@ -2,14 +2,11 @@
 
 from __future__ import annotations
 
-import numpy as np
-import pytest
 from pitlane_elo.config import EloConfig
 from pitlane_elo.data import RaceEntry
 from pitlane_elo.ratings.constructor_elo import ConstructorElo
 
 from tests.conftest import make_race_entry
-
 
 # ---------------------------------------------------------------------------
 # Helper: make_race_entry with a real team name

--- a/packages/pitlane-elo/tests/separation/test_alpha_estimation.py
+++ b/packages/pitlane-elo/tests/separation/test_alpha_estimation.py
@@ -4,38 +4,29 @@ from __future__ import annotations
 
 from pathlib import Path
 
+import numpy as np
+
 from pitlane_elo.separation.alpha_estimation import estimate_alpha
 
 
 class TestEstimateAlpha:
-    def test_returns_float_in_default_bounds(self, multi_race_db: Path) -> None:
-        """Result should be in [0.0, 15.0] (default bounds)."""
+    def test_returns_float(self, multi_race_db: Path) -> None:
+        """Result is a float."""
         alpha = estimate_alpha(2023, 2024, db_path=multi_race_db)
         assert isinstance(alpha, float)
-        assert 0.0 <= alpha <= 15.0
 
-    def test_custom_bounds_respected(self, multi_race_db: Path) -> None:
-        """Returned alpha must lie within the custom bounds."""
-        alpha = estimate_alpha(2023, 2024, db_path=multi_race_db, alpha_bounds=(2.0, 5.0))
-        assert 2.0 <= alpha <= 5.0
-
-    def test_n_steps_one_no_error(self, multi_race_db: Path) -> None:
-        """n_steps=1 should return the single candidate without error."""
-        alpha = estimate_alpha(2023, 2024, db_path=multi_race_db, n_steps=1)
-        assert alpha == 0.0  # linspace(0, 15, 1) = [0.0]
-
-    def test_empty_data_returns_lower_bound(self, tmp_db: Path) -> None:
-        """Year range with no data returns alpha_bounds[0]."""
-        alpha = estimate_alpha(1900, 1901, db_path=tmp_db)
-        assert alpha == 0.0
-
-    def test_custom_bounds_empty_data_returns_lower_bound(self, tmp_db: Path) -> None:
-        """Empty data with custom bounds returns the lower bound."""
-        alpha = estimate_alpha(1900, 1901, db_path=tmp_db, alpha_bounds=(3.0, 8.0))
-        assert alpha == 3.0
+    def test_result_is_finite(self, multi_race_db: Path) -> None:
+        """OLS result must be a finite number, not NaN or inf."""
+        alpha = estimate_alpha(2023, 2024, db_path=multi_race_db)
+        assert np.isfinite(alpha)
 
     def test_deterministic(self, multi_race_db: Path) -> None:
-        """Same inputs produce the same result (grid search is deterministic)."""
-        alpha1 = estimate_alpha(2023, 2024, db_path=multi_race_db, n_steps=5)
-        alpha2 = estimate_alpha(2023, 2024, db_path=multi_race_db, n_steps=5)
+        """Same inputs always produce the same result (no randomness in OLS)."""
+        alpha1 = estimate_alpha(2023, 2024, db_path=multi_race_db)
+        alpha2 = estimate_alpha(2023, 2024, db_path=multi_race_db)
         assert alpha1 == alpha2
+
+    def test_empty_data_returns_zero(self, tmp_db: Path) -> None:
+        """Year range with no data returns 0.0 (safe default)."""
+        alpha = estimate_alpha(1900, 1901, db_path=tmp_db)
+        assert alpha == 0.0

--- a/packages/pitlane-elo/tests/separation/test_alpha_estimation.py
+++ b/packages/pitlane-elo/tests/separation/test_alpha_estimation.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 from pathlib import Path
 
 import numpy as np
-
 from pitlane_elo.separation.alpha_estimation import estimate_alpha
 
 

--- a/packages/pitlane-elo/tests/separation/test_alpha_estimation.py
+++ b/packages/pitlane-elo/tests/separation/test_alpha_estimation.py
@@ -1,0 +1,41 @@
+"""Tests for pitlane_elo.separation.alpha_estimation."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from pitlane_elo.separation.alpha_estimation import estimate_alpha
+
+
+class TestEstimateAlpha:
+    def test_returns_float_in_default_bounds(self, multi_race_db: Path) -> None:
+        """Result should be in [0.0, 15.0] (default bounds)."""
+        alpha = estimate_alpha(2023, 2024, db_path=multi_race_db)
+        assert isinstance(alpha, float)
+        assert 0.0 <= alpha <= 15.0
+
+    def test_custom_bounds_respected(self, multi_race_db: Path) -> None:
+        """Returned alpha must lie within the custom bounds."""
+        alpha = estimate_alpha(2023, 2024, db_path=multi_race_db, alpha_bounds=(2.0, 5.0))
+        assert 2.0 <= alpha <= 5.0
+
+    def test_n_steps_one_no_error(self, multi_race_db: Path) -> None:
+        """n_steps=1 should return the single candidate without error."""
+        alpha = estimate_alpha(2023, 2024, db_path=multi_race_db, n_steps=1)
+        assert alpha == 0.0  # linspace(0, 15, 1) = [0.0]
+
+    def test_empty_data_returns_lower_bound(self, tmp_db: Path) -> None:
+        """Year range with no data returns alpha_bounds[0]."""
+        alpha = estimate_alpha(1900, 1901, db_path=tmp_db)
+        assert alpha == 0.0
+
+    def test_custom_bounds_empty_data_returns_lower_bound(self, tmp_db: Path) -> None:
+        """Empty data with custom bounds returns the lower bound."""
+        alpha = estimate_alpha(1900, 1901, db_path=tmp_db, alpha_bounds=(3.0, 8.0))
+        assert alpha == 3.0
+
+    def test_deterministic(self, multi_race_db: Path) -> None:
+        """Same inputs produce the same result (grid search is deterministic)."""
+        alpha1 = estimate_alpha(2023, 2024, db_path=multi_race_db, n_steps=5)
+        alpha2 = estimate_alpha(2023, 2024, db_path=multi_race_db, n_steps=5)
+        assert alpha1 == alpha2

--- a/packages/pitlane-elo/tests/separation/test_decompose.py
+++ b/packages/pitlane-elo/tests/separation/test_decompose.py
@@ -1,0 +1,187 @@
+"""Tests for TeammateNormaliser in pitlane_elo.separation.decompose."""
+
+from __future__ import annotations
+
+from pitlane_elo.data import RaceEntry
+from pitlane_elo.separation.decompose import TeammateData, TeammateNormaliser
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+
+
+def _entry(
+    driver_id: str,
+    team: str,
+    finish: int | None,
+    laps: int = 57,
+) -> RaceEntry:
+    return {
+        "year": 2024,
+        "round": 1,
+        "session_type": "R",
+        "driver_id": driver_id,
+        "team": team,
+        "laps_completed": laps,
+        "status": "Finished" if finish is not None else "Retired",
+        "dnf_category": "none",
+        "is_wet_race": False,
+        "is_street_circuit": False,
+        "finish_position": finish,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestTeammateNormaliser:
+    def test_empty_entries_returns_empty(self) -> None:
+        norm = TeammateNormaliser()
+        result = norm.record([], {})
+        assert result == []
+        assert norm.history == {}
+
+    def test_single_driver_per_team_skipped(self) -> None:
+        """One driver per team → no teammate pair → no records."""
+        entries = [
+            _entry("A", "TeamA", 1),
+            _entry("B", "TeamB", 2),
+        ]
+        ratings = {"A": 1.0, "B": -0.5}
+        norm = TeammateNormaliser()
+        result = norm.record(entries, ratings)
+        assert result == []
+        assert norm.history == {}
+
+    def test_two_teams_standard_case(self) -> None:
+        """Standard 4-driver, 2-team race produces 4 records (bidirectional)."""
+        entries = [
+            _entry("A1", "TeamA", 1),
+            _entry("A2", "TeamA", 2),
+            _entry("B1", "TeamB", 3),
+            _entry("B2", "TeamB", 4),
+        ]
+        ratings = {"A1": 2.0, "A2": 1.0, "B1": -0.5, "B2": -1.5}
+        norm = TeammateNormaliser()
+        result = norm.record(entries, ratings)
+
+        assert len(result) == 4
+        assert len(norm.history["A1"]) == 1
+        assert len(norm.history["A2"]) == 1
+        assert len(norm.history["B1"]) == 1
+        assert len(norm.history["B2"]) == 1
+
+    def test_delta_values_correct(self) -> None:
+        """Delta = driver_rating - teammate_rating."""
+        entries = [
+            _entry("A1", "TeamA", 1),
+            _entry("A2", "TeamA", 2),
+        ]
+        ratings = {"A1": 3.0, "A2": 1.0}
+        norm = TeammateNormaliser()
+        norm.record(entries, ratings)
+
+        rec_a1 = norm.history["A1"][0]
+        assert rec_a1["driver_rating"] == 3.0
+        assert rec_a1["teammate_rating"] == 1.0
+        assert rec_a1["delta"] == 2.0
+
+    def test_delta_sign_symmetric(self) -> None:
+        """A→B and B→A records have opposite-sign deltas."""
+        entries = [
+            _entry("A1", "TeamA", 1),
+            _entry("A2", "TeamA", 2),
+        ]
+        ratings = {"A1": 3.0, "A2": 1.0}
+        norm = TeammateNormaliser()
+        norm.record(entries, ratings)
+
+        assert norm.history["A1"][0]["delta"] == -norm.history["A2"][0]["delta"]
+
+    def test_dnf_driver_excluded(self) -> None:
+        """Driver with finish_position=None → their team has ≤1 valid finisher → no records."""
+        entries = [
+            _entry("A1", "TeamA", 1),
+            _entry("A2", "TeamA", None),  # DNF, no finish_position
+            _entry("B1", "TeamB", 3),
+            _entry("B2", "TeamB", 4),
+        ]
+        ratings = {"A1": 1.0, "A2": 0.5, "B1": -0.5, "B2": -1.0}
+        norm = TeammateNormaliser()
+        result = norm.record(entries, ratings)
+
+        # TeamA produces no records (only A1 has finish_position)
+        assert "A1" not in norm.history
+        assert "A2" not in norm.history
+        # TeamB still produces 2 records
+        assert len(result) == 2
+
+    def test_both_dnf_team_skipped(self) -> None:
+        """Both drivers with no finish_position → team skipped entirely."""
+        entries = [
+            _entry("A1", "TeamA", None),
+            _entry("A2", "TeamA", None),
+        ]
+        ratings = {"A1": 1.0, "A2": 0.5}
+        norm = TeammateNormaliser()
+        result = norm.record(entries, ratings)
+        assert result == []
+
+    def test_history_accumulates_across_races(self) -> None:
+        """Calling record() twice grows history length to 2 per driver."""
+        entries = [
+            _entry("A1", "TeamA", 1),
+            _entry("A2", "TeamA", 2),
+        ]
+        ratings = {"A1": 1.0, "A2": -1.0}
+        norm = TeammateNormaliser()
+        norm.record(entries, ratings)
+        norm.record(entries, ratings)
+
+        assert len(norm.history["A1"]) == 2
+        assert len(norm.history["A2"]) == 2
+
+    def test_driver_missing_from_ratings_skipped(self) -> None:
+        """Driver not present in ratings dict → their team is skipped."""
+        entries = [
+            _entry("A1", "TeamA", 1),
+            _entry("A2", "TeamA", 2),
+        ]
+        # A2 missing from ratings
+        ratings = {"A1": 1.0}
+        norm = TeammateNormaliser()
+        result = norm.record(entries, ratings)
+        assert result == []
+
+    def test_three_car_team_uses_two_best(self) -> None:
+        """3-car team: only the two drivers with lowest finish_position are used."""
+        entries = [
+            _entry("A1", "TeamA", 1),
+            _entry("A2", "TeamA", 3),
+            _entry("A3", "TeamA", 5),  # third car — should be ignored
+        ]
+        ratings = {"A1": 3.0, "A2": 1.0, "A3": -2.0}
+        norm = TeammateNormaliser()
+        result = norm.record(entries, ratings)
+
+        assert len(result) == 2
+        driver_ids = {r["driver_id"] for r in result}
+        assert driver_ids == {"A1", "A2"}
+        assert "A3" not in norm.history
+
+    def test_year_round_preserved_in_record(self) -> None:
+        """TeammateData carries year and round from the entries."""
+        entries = [
+            {**_entry("A1", "TeamA", 1), "year": 2023, "round": 5},
+            {**_entry("A2", "TeamA", 2), "year": 2023, "round": 5},
+        ]
+        ratings = {"A1": 1.0, "A2": 0.5}
+        norm = TeammateNormaliser()
+        norm.record(entries, ratings)
+
+        rec = norm.history["A1"][0]
+        assert rec["year"] == 2023
+        assert rec["round"] == 5

--- a/packages/pitlane-elo/tests/separation/test_decompose.py
+++ b/packages/pitlane-elo/tests/separation/test_decompose.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 from pitlane_elo.data import RaceEntry
-from pitlane_elo.separation.decompose import TeammateData, TeammateNormaliser
-
+from pitlane_elo.separation.decompose import TeammateNormaliser
 
 # ---------------------------------------------------------------------------
 # Helper

--- a/packages/pitlane-elo/tests/test_config.py
+++ b/packages/pitlane-elo/tests/test_config.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import dataclasses
+
 import pytest
 from pitlane_elo.config import ENDURE_ELO_DEFAULT, SPEED_ELO_DEFAULT, EloConfig
 
@@ -22,3 +24,23 @@ class TestEloConfig:
         assert ENDURE_ELO_DEFAULT.name == "endure-elo-default"
         assert SPEED_ELO_DEFAULT.name == "speed-elo-default"
         assert SPEED_ELO_DEFAULT.exclude_mechanical_dnf is False
+
+    def test_alpha_default_is_zero(self) -> None:
+        cfg = EloConfig(name="test")
+        assert cfg.alpha == 0.0
+
+    def test_alpha_in_asdict(self) -> None:
+        """alpha must appear in dataclasses.asdict output for JSON serialisation."""
+        cfg = EloConfig(name="test")
+        d = dataclasses.asdict(cfg)
+        assert "alpha" in d
+        assert d["alpha"] == 0.0
+
+    def test_existing_configs_have_alpha_zero(self) -> None:
+        """Pre-built configs default to alpha=0.0 (backward compat)."""
+        assert ENDURE_ELO_DEFAULT.alpha == 0.0
+        assert SPEED_ELO_DEFAULT.alpha == 0.0
+
+    def test_alpha_custom_value(self) -> None:
+        cfg = EloConfig(name="test", alpha=7.3)
+        assert cfg.alpha == pytest.approx(7.3)


### PR DESCRIPTION
## Summary

- **Fixes in-sample bug**: ratings were recorded *after* `process_race`, meaning each race's outcome was already baked in — trivially biasing toward `alpha=0`
- **Fixes wrong objective**: maximizing race-winner log-likelihood always favors `alpha=0` because cars do cause wins; removing car signal hurts winner prediction regardless of the true alpha
- **Correct method**: OLS variance decomposition from van Kesteren & Bergkamp 2023 §7.3 — records pre-race `(driver_rating, constructor_rating)` pairs out-of-sample, returns `Cov(driver, constructor) / Var(constructor)`

Produces `alpha ≈ 0.64–0.77` (closer to expected range given our independent model scales vs. van Kesteren's team-mean construction).

**Removed**: `alpha_bounds`, `n_steps`, `on_step` params and the grid search loop; `--n-steps` CLI flag; `_RaceObs` TypedDict; `_inclusion_exclusion` import.

## Test plan

- [x] `uv run --directory packages/pitlane-elo pytest tests/separation/test_alpha_estimation.py -v` — 4 tests pass
- [x] Smoke: `uv run -m pitlane_elo.cli estimate-alpha --start-year 2014` → `alpha ≈ 0.77`
- [x] Smoke: `uv run -m pitlane_elo.cli estimate-alpha` → `alpha ≈ 0.64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)