### PR TITLE
fix(elo): exclude DNS entries from win probability, decouple ratings persistence

### DIFF
--- a/packages/pitlane-elo/src/pitlane_elo/cli.py
+++ b/packages/pitlane-elo/src/pitlane_elo/cli.py
@@ -492,7 +492,19 @@ def evaluate_van_kesteren_cmd(
 @click.option("--end-year", type=int, default=2026, help="Last season (inclusive).")
 @click.option("--session-type", type=click.Choice(["R", "S"]), default="R", help="Session type to snapshot.")
 @click.option("--db-path", type=click.Path(), default=None, help="Override database path.")
-def snapshot(start_year: int, end_year: int, session_type: str, db_path: str | None) -> None:
+@click.option(
+    "--retention-years",
+    type=int,
+    default=None,
+    help="Years of history kept per checkpoint (default: PITLANE_STATE_RETENTION_YEARS env var, then 5).",
+)
+def snapshot(
+    start_year: int,
+    end_year: int,
+    session_type: str,
+    db_path: str | None,
+    retention_years: int | None,
+) -> None:
     """Compute and persist ELO snapshots (pre-race ratings + win probs) for every race.
 
     Runs the calibrated endure-Elo model in a predict-then-update loop and writes
@@ -504,7 +516,13 @@ def snapshot(start_year: int, end_year: int, session_type: str, db_path: str | N
         raise click.ClickException(f"Database not found: {path}. Check your database path.")
     click.echo(f"Running calibrated endure-Elo snapshot ({start_year}–{end_year})...")
     t0 = time.perf_counter()
-    n = build_snapshots(start_year, end_year, db_path=path, session_type=session_type)
+    n = build_snapshots(
+        start_year,
+        end_year,
+        db_path=path,
+        session_type=session_type,
+        retention_years=retention_years,
+    )
     elapsed = time.perf_counter() - t0
     if n == 0:
         raise click.ClickException(
@@ -519,7 +537,19 @@ def snapshot(start_year: int, end_year: int, session_type: str, db_path: str | N
 @click.option("--round", "round_num", type=int, required=True, help="Round number of the race to add.")
 @click.option("--session-type", type=click.Choice(["R", "S"]), default="R", help="Session type.")
 @click.option("--db-path", type=click.Path(), default=None, help="Override database path.")
-def snapshot_add(year: int, round_num: int, session_type: str, db_path: str | None) -> None:
+@click.option(
+    "--retention-years",
+    type=int,
+    default=None,
+    help="Years of history kept per checkpoint (default: PITLANE_STATE_RETENTION_YEARS env var, then 5).",
+)
+def snapshot_add(
+    year: int,
+    round_num: int,
+    session_type: str,
+    db_path: str | None,
+    retention_years: int | None,
+) -> None:
     """Incrementally add one race to the snapshot (~1 second).
 
     Loads the model state saved after the previous race, predicts probabilities,
@@ -532,7 +562,13 @@ def snapshot_add(year: int, round_num: int, session_type: str, db_path: str | No
     path = Path(db_path) if db_path else get_db_path()
     click.echo(f"Adding snapshot for {year} R{round_num} ({session_type})...")
     t0 = time.perf_counter()
-    n = add_race_snapshot(year, round_num, session_type=session_type, db_path=path)
+    n = add_race_snapshot(
+        year,
+        round_num,
+        session_type=session_type,
+        db_path=path,
+        retention_years=retention_years,
+    )
     elapsed = time.perf_counter() - t0
     click.echo(f"Wrote {n:,} rows in {elapsed:.1f}s.")
 
@@ -540,7 +576,17 @@ def snapshot_add(year: int, round_num: int, session_type: str, db_path: str | No
 @main.command("snapshot-catchup")
 @click.option("--session-type", type=click.Choice(["R", "S"]), default="R", help="Session type.")
 @click.option("--db-path", type=click.Path(), default=None, help="Override database path.")
-def snapshot_catchup(session_type: str, db_path: str | None) -> None:
+@click.option(
+    "--retention-years",
+    type=int,
+    default=None,
+    help="Years of history kept per checkpoint (default: PITLANE_STATE_RETENTION_YEARS env var, then 5).",
+)
+def snapshot_catchup(
+    session_type: str,
+    db_path: str | None,
+    retention_years: int | None,
+) -> None:
     """Add every race in race_entries not yet covered by a model-state checkpoint.
 
     Finds the latest checkpoint, then processes all subsequent races in
@@ -550,7 +596,11 @@ def snapshot_catchup(session_type: str, db_path: str | None) -> None:
     path = Path(db_path) if db_path else get_db_path()
     click.echo(f"Catching up snapshots ({session_type})...")
     t0 = time.perf_counter()
-    n = catchup_snapshots(session_type=session_type, db_path=path)
+    n = catchup_snapshots(
+        session_type=session_type,
+        db_path=path,
+        retention_years=retention_years,
+    )
     elapsed = time.perf_counter() - t0
     if n == 0:
         click.echo("Already up to date.")

--- a/packages/pitlane-elo/src/pitlane_elo/ratings/endure_elo.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings/endure_elo.py
@@ -30,7 +30,10 @@ from pitlane_elo.ratings.base import RatingModel
 def _inclusion_exclusion(lambdas: np.ndarray) -> np.ndarray:
     """Compute win probabilities via inclusion-exclusion (eq 60).
 
-    JIT-compiled to native ARM with parallel driver iteration.
+    JIT-compiled to native ARM with parallel driver iteration. Callers must
+    pass lambdas corresponding only to drivers who actually started the race;
+    DNS entries inflate the power-set size and dilute every starter's
+    probability.
     """
     n = len(lambdas)
     probs = np.zeros(n)

--- a/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
@@ -108,8 +108,7 @@ class RatingsStore:
     def active_driver_ids(self, year: int, session_type: str) -> set[str]:
         """Driver IDs with at least one entry within ``retention_years`` of ``year``."""
         cursor = self.con.execute(
-            "SELECT DISTINCT driver_id FROM race_entries "
-            "WHERE session_type = ? AND year >= ? AND year <= ?",
+            "SELECT DISTINCT driver_id FROM race_entries WHERE session_type = ? AND year >= ? AND year <= ?",
             [session_type, year - self.retention_years, year],
         )
         return {row[0] for row in cursor.fetchall()}
@@ -145,8 +144,7 @@ class RatingsStore:
     ) -> tuple[dict[str, float], dict[str, float]]:
         """Return ``(ratings, k_factors)`` saved after the given race (empty if missing)."""
         cursor = self.con.execute(
-            "SELECT driver_id, rating, k_factor FROM elo_model_state "
-            "WHERE year = ? AND round = ? AND session_type = ?",
+            "SELECT driver_id, rating, k_factor FROM elo_model_state WHERE year = ? AND round = ? AND session_type = ?",
             [year, round_num, session_type],
         )
         ratings: dict[str, float] = {}

--- a/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
@@ -5,14 +5,15 @@ schema DDL, snapshot-row upserts, post-race model-state checkpoints, and the
 checkpoint-discovery queries used to drive incremental adds.
 
 Callers pass an open connection and a retention policy; the store neither
-opens nor closes the connection. ``load_checkpoint`` returns plain dicts so
-model hydration stays explicit — no method here mutates a model.
+opens nor closes the connection. ``load_checkpoint`` returns a
+:class:`ModelState` so model hydration stays explicit — no method here
+mutates a model.
 """
 
 from __future__ import annotations
 
 import contextlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, NamedTuple
 
 import duckdb
 
@@ -84,6 +85,52 @@ VALUES (?, ?, ?, ?, ?, ?)
 """
 
 
+# ---------------------------------------------------------------------------
+# Typed record shapes
+# ---------------------------------------------------------------------------
+
+
+class Checkpoint(NamedTuple):
+    """Identifier for a persisted model-state checkpoint."""
+
+    year: int
+    round: int
+    session_type: str
+
+
+class RaceKey(NamedTuple):
+    """Primary key fragment identifying a single race within a session type."""
+
+    year: int
+    round: int
+
+
+class ModelState(NamedTuple):
+    """Per-driver ratings and k-factors loaded from a checkpoint."""
+
+    ratings: dict[str, float]
+    k_factors: dict[str, float]
+
+
+class SnapshotRow(NamedTuple):
+    """One row destined for ``elo_snapshots``. Field order matches the INSERT.
+
+    Declared as a NamedTuple so ``executemany`` treats instances as positional
+    parameter tuples while callers get named-field access.
+    """
+
+    year: int
+    round: int
+    session_type: str
+    driver_id: str
+    pre_race_rating: float
+    pre_race_k: float
+    win_probability: float
+    podium_probability: float
+    finish_position: int | None
+    dnf_category: str
+
+
 class RatingsStore:
     """DuckDB-backed store for ELO snapshot rows and model-state checkpoints."""
 
@@ -129,7 +176,7 @@ class RatingsStore:
         When ``active_driver_ids`` is supplied, drivers outside that set are
         pruned from the checkpoint so the table does not grow unboundedly.
         """
-        rows = [
+        rows: list[tuple[int, int, str, str, float, float]] = [
             (year, round_num, session_type, driver_id, rating, model.k_factors[driver_id])
             for driver_id, rating in model.ratings.items()
             if active_driver_ids is None or driver_id in active_driver_ids
@@ -141,8 +188,8 @@ class RatingsStore:
         year: int,
         round_num: int,
         session_type: str,
-    ) -> tuple[dict[str, float], dict[str, float]]:
-        """Return ``(ratings, k_factors)`` saved after the given race (empty if missing)."""
+    ) -> ModelState:
+        """Return ``ModelState`` saved after the given race (empty if missing)."""
         cursor = self.con.execute(
             "SELECT driver_id, rating, k_factor FROM elo_model_state WHERE year = ? AND round = ? AND session_type = ?",
             [year, round_num, session_type],
@@ -152,10 +199,10 @@ class RatingsStore:
         for driver_id, rating, k_factor in cursor.fetchall():
             ratings[driver_id] = rating
             k_factors[driver_id] = k_factor
-        return ratings, k_factors
+        return ModelState(ratings=ratings, k_factors=k_factors)
 
-    def latest_checkpoint(self, session_type: str) -> tuple[int, int, str] | None:
-        """Most recently persisted (year, round, session_type), or None."""
+    def latest_checkpoint(self, session_type: str) -> Checkpoint | None:
+        """Most recently persisted checkpoint for the session type, or None."""
         try:
             cursor = self.con.execute(
                 "SELECT year, round, session_type FROM elo_model_state "
@@ -168,14 +215,14 @@ class RatingsStore:
         row = cursor.fetchone()
         if row is None:
             return None
-        return (row[0], row[1], row[2])
+        return Checkpoint(year=row[0], round=row[1], session_type=row[2])
 
     def checkpoint_before(
         self,
         year: int,
         round_num: int,
         session_type: str,
-    ) -> tuple[int, int, str] | None:
+    ) -> Checkpoint | None:
         """Most recent checkpoint strictly before ``(year, round_num)``, or None."""
         try:
             cursor = self.con.execute(
@@ -190,7 +237,7 @@ class RatingsStore:
         row = cursor.fetchone()
         if row is None:
             return None
-        return (row[0], row[1], row[2])
+        return Checkpoint(year=row[0], round=row[1], session_type=row[2])
 
     def gap_races_between(
         self,
@@ -199,8 +246,8 @@ class RatingsStore:
         target_year: int,
         target_round: int,
         session_type: str,
-    ) -> list[tuple[int, int]]:
-        """``(year, round)`` pairs in race_entries strictly between checkpoint and target."""
+    ) -> list[RaceKey]:
+        """``RaceKey`` values in race_entries strictly between checkpoint and target."""
         cursor = self.con.execute(
             "SELECT DISTINCT year, round FROM race_entries "
             "WHERE session_type = ? "
@@ -209,11 +256,11 @@ class RatingsStore:
             "ORDER BY year, round",
             [session_type, cp_year, cp_year, cp_round, target_year, target_year, target_round],
         )
-        return [(r[0], r[1]) for r in cursor.fetchall()]
+        return [RaceKey(year=r[0], round=r[1]) for r in cursor.fetchall()]
 
     # ----- snapshot rows --------------------------------------------------
 
-    def write_snapshot_rows(self, rows: list[tuple]) -> None:
+    def write_snapshot_rows(self, rows: list[SnapshotRow]) -> None:
         """Upsert a batch of snapshot rows. Safe to call with an empty list."""
         if not rows:
             return
@@ -249,8 +296,8 @@ class RatingsStore:
         cp_year: int,
         cp_round: int,
         session_type: str,
-    ) -> list[tuple[int, int]]:
-        """``(year, round)`` pairs in race_entries after the given checkpoint."""
+    ) -> list[RaceKey]:
+        """``RaceKey`` values in race_entries after the given checkpoint."""
         cursor = self.con.execute(
             "SELECT DISTINCT year, round FROM race_entries "
             "WHERE session_type = ? "
@@ -258,7 +305,13 @@ class RatingsStore:
             "ORDER BY year, round",
             [session_type, cp_year, cp_year, cp_round],
         )
-        return [(r[0], r[1]) for r in cursor.fetchall()]
+        return [RaceKey(year=r[0], round=r[1]) for r in cursor.fetchall()]
 
 
-__all__ = ["RatingsStore"]
+__all__ = [
+    "Checkpoint",
+    "ModelState",
+    "RaceKey",
+    "RatingsStore",
+    "SnapshotRow",
+]

--- a/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
@@ -1,0 +1,266 @@
+"""Persistence layer for ELO ratings: snapshots and model-state checkpoints.
+
+Owns every DuckDB interaction previously tangled inside ``snapshots.py``:
+schema DDL, snapshot-row upserts, post-race model-state checkpoints, and the
+checkpoint-discovery queries used to drive incremental adds.
+
+Callers pass an open connection and a retention policy; the store neither
+opens nor closes the connection. ``load_checkpoint`` returns plain dicts so
+model hydration stays explicit — no method here mutates a model.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING
+
+import duckdb
+
+from pitlane_elo.data import RACE_COLS, RaceEntry, order_race_entries
+
+if TYPE_CHECKING:
+    from pitlane_elo.ratings.endure_elo import EndureElo
+
+_CREATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS elo_snapshots (
+    year               INTEGER   NOT NULL,
+    round              INTEGER   NOT NULL,
+    session_type       VARCHAR   NOT NULL,
+    driver_id          VARCHAR   NOT NULL,
+    pre_race_rating    DOUBLE    NOT NULL,
+    pre_race_k         DOUBLE    NOT NULL,
+    win_probability    DOUBLE    NOT NULL,
+    podium_probability DOUBLE    NOT NULL DEFAULT 0.0,
+    finish_position    INTEGER,
+    dnf_category       VARCHAR   NOT NULL DEFAULT 'none',
+    created_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (year, round, session_type, driver_id)
+)
+"""
+
+_ADD_PODIUM_COL_SQL = """
+ALTER TABLE elo_snapshots
+    ADD COLUMN podium_probability DOUBLE DEFAULT 0.0
+"""
+
+_CREATE_DRIVER_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_elo_snapshots_driver
+    ON elo_snapshots (driver_id, year, round)
+"""
+
+_CREATE_RACE_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_elo_snapshots_race
+    ON elo_snapshots (year, round, session_type)
+"""
+
+_UPSERT_SNAPSHOT_SQL = """
+INSERT OR REPLACE INTO elo_snapshots
+    (year, round, session_type, driver_id, pre_race_rating, pre_race_k,
+     win_probability, podium_probability, finish_position, dnf_category, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+"""
+
+_CREATE_MODEL_STATE_SQL = """
+CREATE TABLE IF NOT EXISTS elo_model_state (
+    year         INTEGER NOT NULL,
+    round        INTEGER NOT NULL,
+    session_type VARCHAR NOT NULL,
+    driver_id    VARCHAR NOT NULL,
+    rating       DOUBLE  NOT NULL,
+    k_factor     DOUBLE  NOT NULL,
+    PRIMARY KEY (year, round, session_type, driver_id)
+)
+"""
+
+_CREATE_MODEL_STATE_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_elo_model_state_race
+    ON elo_model_state (year, round, session_type)
+"""
+
+_UPSERT_STATE_SQL = """
+INSERT OR REPLACE INTO elo_model_state
+    (year, round, session_type, driver_id, rating, k_factor)
+VALUES (?, ?, ?, ?, ?, ?)
+"""
+
+
+class RatingsStore:
+    """DuckDB-backed store for ELO snapshot rows and model-state checkpoints."""
+
+    def __init__(self, con: duckdb.DuckDBPyConnection, *, retention_years: int) -> None:
+        self.con = con
+        self.retention_years = retention_years
+
+    # ----- schema ---------------------------------------------------------
+
+    def ensure_schema(self) -> None:
+        """Create tables and indexes if they do not exist. Idempotent."""
+        self.con.execute(_CREATE_TABLE_SQL)
+        with contextlib.suppress(duckdb.CatalogException):
+            self.con.execute(_ADD_PODIUM_COL_SQL)
+        self.con.execute(_CREATE_DRIVER_INDEX_SQL)
+        self.con.execute(_CREATE_RACE_INDEX_SQL)
+        self.con.execute(_CREATE_MODEL_STATE_SQL)
+        self.con.execute(_CREATE_MODEL_STATE_INDEX_SQL)
+
+    # ----- active driver pruning ------------------------------------------
+
+    def active_driver_ids(self, year: int, session_type: str) -> set[str]:
+        """Driver IDs with at least one entry within ``retention_years`` of ``year``."""
+        cursor = self.con.execute(
+            "SELECT DISTINCT driver_id FROM race_entries "
+            "WHERE session_type = ? AND year >= ? AND year <= ?",
+            [session_type, year - self.retention_years, year],
+        )
+        return {row[0] for row in cursor.fetchall()}
+
+    # ----- model-state checkpoints ----------------------------------------
+
+    def save_checkpoint(
+        self,
+        model: EndureElo,
+        year: int,
+        round_num: int,
+        session_type: str,
+        *,
+        active_driver_ids: set[str] | None = None,
+    ) -> None:
+        """Persist (rating, k_factor) for each currently-known driver.
+
+        When ``active_driver_ids`` is supplied, drivers outside that set are
+        pruned from the checkpoint so the table does not grow unboundedly.
+        """
+        rows = [
+            (year, round_num, session_type, driver_id, rating, model.k_factors[driver_id])
+            for driver_id, rating in model.ratings.items()
+            if active_driver_ids is None or driver_id in active_driver_ids
+        ]
+        self.con.executemany(_UPSERT_STATE_SQL, rows)
+
+    def load_checkpoint(
+        self,
+        year: int,
+        round_num: int,
+        session_type: str,
+    ) -> tuple[dict[str, float], dict[str, float]]:
+        """Return ``(ratings, k_factors)`` saved after the given race (empty if missing)."""
+        cursor = self.con.execute(
+            "SELECT driver_id, rating, k_factor FROM elo_model_state "
+            "WHERE year = ? AND round = ? AND session_type = ?",
+            [year, round_num, session_type],
+        )
+        ratings: dict[str, float] = {}
+        k_factors: dict[str, float] = {}
+        for driver_id, rating, k_factor in cursor.fetchall():
+            ratings[driver_id] = rating
+            k_factors[driver_id] = k_factor
+        return ratings, k_factors
+
+    def latest_checkpoint(self, session_type: str) -> tuple[int, int, str] | None:
+        """Most recently persisted (year, round, session_type), or None."""
+        try:
+            cursor = self.con.execute(
+                "SELECT year, round, session_type FROM elo_model_state "
+                "WHERE session_type = ? "
+                "ORDER BY year DESC, round DESC LIMIT 1",
+                [session_type],
+            )
+        except duckdb.CatalogException:
+            return None
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return (row[0], row[1], row[2])
+
+    def checkpoint_before(
+        self,
+        year: int,
+        round_num: int,
+        session_type: str,
+    ) -> tuple[int, int, str] | None:
+        """Most recent checkpoint strictly before ``(year, round_num)``, or None."""
+        try:
+            cursor = self.con.execute(
+                "SELECT year, round, session_type FROM elo_model_state "
+                "WHERE session_type = ? "
+                "  AND (year < ? OR (year = ? AND round < ?)) "
+                "ORDER BY year DESC, round DESC LIMIT 1",
+                [session_type, year, year, round_num],
+            )
+        except duckdb.CatalogException:
+            return None
+        row = cursor.fetchone()
+        if row is None:
+            return None
+        return (row[0], row[1], row[2])
+
+    def gap_races_between(
+        self,
+        cp_year: int,
+        cp_round: int,
+        target_year: int,
+        target_round: int,
+        session_type: str,
+    ) -> list[tuple[int, int]]:
+        """``(year, round)`` pairs in race_entries strictly between checkpoint and target."""
+        cursor = self.con.execute(
+            "SELECT DISTINCT year, round FROM race_entries "
+            "WHERE session_type = ? "
+            "  AND (year > ? OR (year = ? AND round > ?)) "
+            "  AND (year < ? OR (year = ? AND round < ?)) "
+            "ORDER BY year, round",
+            [session_type, cp_year, cp_year, cp_round, target_year, target_year, target_round],
+        )
+        return [(r[0], r[1]) for r in cursor.fetchall()]
+
+    # ----- snapshot rows --------------------------------------------------
+
+    def write_snapshot_rows(self, rows: list[tuple]) -> None:
+        """Upsert a batch of snapshot rows. Safe to call with an empty list."""
+        if not rows:
+            return
+        self.con.executemany(_UPSERT_SNAPSHOT_SQL, rows)
+
+    # ----- race-entries read ----------------------------------------------
+
+    def read_race_entries(
+        self,
+        year: int,
+        round_num: int,
+        session_type: str,
+    ) -> list[RaceEntry]:
+        """Load a single race's entries, ordered by finishing position."""
+        cursor = self.con.execute(
+            f"SELECT {RACE_COLS} FROM race_entries "
+            "WHERE year = ? AND round = ? AND session_type = ? "
+            "ORDER BY driver_id",
+            [year, round_num, session_type],
+        )
+        entry_rows = cursor.fetchall()
+        if not entry_rows:
+            return []
+        columns = [desc[0] for desc in cursor.description]
+        entries: list[RaceEntry] = [
+            dict(zip(columns, row, strict=True))  # type: ignore[misc]
+            for row in entry_rows
+        ]
+        return order_race_entries(entries)
+
+    def pending_races_after_checkpoint(
+        self,
+        cp_year: int,
+        cp_round: int,
+        session_type: str,
+    ) -> list[tuple[int, int]]:
+        """``(year, round)`` pairs in race_entries after the given checkpoint."""
+        cursor = self.con.execute(
+            "SELECT DISTINCT year, round FROM race_entries "
+            "WHERE session_type = ? "
+            "  AND (year > ? OR (year = ? AND round > ?)) "
+            "ORDER BY year, round",
+            [session_type, cp_year, cp_year, cp_round],
+        )
+        return [(r[0], r[1]) for r in cursor.fetchall()]
+
+
+__all__ = ["RatingsStore"]

--- a/packages/pitlane-elo/src/pitlane_elo/snapshots.py
+++ b/packages/pitlane-elo/src/pitlane_elo/snapshots.py
@@ -28,7 +28,7 @@ from pitlane_elo.data import (
     group_entries_by_race,
 )
 from pitlane_elo.ratings.endure_elo import EndureElo
-from pitlane_elo.ratings_store import RatingsStore
+from pitlane_elo.ratings_store import RatingsStore, SnapshotRow
 
 # ---------------------------------------------------------------------------
 # Retention policy
@@ -100,7 +100,7 @@ def predict_snapshot_rows(
     session_type: str,
     *,
     current_year: int | None,
-) -> tuple[list[tuple], int]:
+) -> tuple[list[SnapshotRow], int]:
     """Compute pre-race snapshot rows for one race. Does not update the model.
 
     Applies season decay when the race crosses a year boundary from
@@ -135,18 +135,18 @@ def predict_snapshot_rows(
     finish_map = {e["driver_id"]: e.get("finish_position") for e in starters}
     dnf_map = {e["driver_id"]: e.get("dnf_category") or "none" for e in starters}
 
-    rows: list[tuple] = [
-        (
-            year,
-            rnd,
-            session_type,
-            driver_id,
-            pre_ratings[driver_id],
-            pre_ks[driver_id],
-            float(prob_map[driver_id]),
-            float(podium_map[driver_id]),
-            finish_map.get(driver_id),
-            dnf_map.get(driver_id, "none"),
+    rows: list[SnapshotRow] = [
+        SnapshotRow(
+            year=year,
+            round=rnd,
+            session_type=session_type,
+            driver_id=driver_id,
+            pre_race_rating=pre_ratings[driver_id],
+            pre_race_k=pre_ks[driver_id],
+            win_probability=float(prob_map[driver_id]),
+            podium_probability=float(podium_map[driver_id]),
+            finish_position=finish_map.get(driver_id),
+            dnf_category=dnf_map.get(driver_id, "none"),
         )
         for driver_id in driver_ids
     ]
@@ -272,11 +272,10 @@ def add_race_snapshot(
                 "Run `pitlane-elo snapshot` first to build the initial state."
             )
 
-        latest_year, latest_round, _ = latest
-        if (year, round_num) < (latest_year, latest_round):
+        if (year, round_num) < (latest.year, latest.round):
             raise click.ClickException(
                 f"{year} R{round_num} is before the latest checkpoint "
-                f"({latest_year} R{latest_round}). "
+                f"({latest.year} R{latest.round}). "
                 "Use `pitlane-elo snapshot` to replay from scratch."
             )
 
@@ -285,12 +284,12 @@ def add_race_snapshot(
             cp_year: int | None = None
             cp_round: int | None = None
         else:
-            cp_year, cp_round, _ = prior
+            cp_year, cp_round = prior.year, prior.round
 
         if cp_year is not None and cp_round is not None:
             gaps = store.gap_races_between(cp_year, cp_round, year, round_num, session_type)
             if gaps:
-                gap_str = ", ".join(f"{y} R{r}" for y, r in gaps)
+                gap_str = ", ".join(f"{g.year} R{g.round}" for g in gaps)
                 raise click.ClickException(
                     f"Cannot add {year} R{round_num}: unprocessed races exist before it: "
                     f"{gap_str}. Add them in order or run `pitlane-elo snapshot-catchup`."
@@ -309,9 +308,9 @@ def add_race_snapshot(
 
         model = EndureElo(ENDURE_ELO_CALIBRATED)
         if cp_year is not None and cp_round is not None:
-            ratings, k_factors = store.load_checkpoint(cp_year, cp_round, session_type)
-            model.ratings = ratings
-            model.k_factors = k_factors
+            state = store.load_checkpoint(cp_year, cp_round, session_type)
+            model.ratings = state.ratings
+            model.k_factors = state.k_factors
 
         snapshot_rows, _ = predict_snapshot_rows(model, race_entries, session_type, current_year=cp_year)
         model.process_race(race_entries)
@@ -360,22 +359,20 @@ def catchup_snapshots(
                 "Run `pitlane-elo snapshot` first to build the initial state."
             )
 
-        cp_year, cp_round, _ = checkpoint
-
         try:
-            pending = store.pending_races_after_checkpoint(cp_year, cp_round, session_type)
+            pending = store.pending_races_after_checkpoint(checkpoint.year, checkpoint.round, session_type)
         except duckdb.CatalogException as err:
             raise click.ClickException("race_entries table not found. Check your database path.") from err
 
         if not pending:
             return 0
 
-        ratings, k_factors = store.load_checkpoint(cp_year, cp_round, session_type)
+        state = store.load_checkpoint(checkpoint.year, checkpoint.round, session_type)
         model = EndureElo(ENDURE_ELO_CALIBRATED)
-        model.ratings = ratings
-        model.k_factors = k_factors
+        model.ratings = state.ratings
+        model.k_factors = state.k_factors
 
-        current_year: int = cp_year
+        current_year: int = checkpoint.year
         active_ids_cache: dict[int, set[str]] = {}
 
         for race_year, race_round in pending:
@@ -420,7 +417,7 @@ _SNAPSHOT_COLS = (
 
 
 def _rows_to_snapshots(rows: list[tuple], columns: list[str]) -> list[EloSnapshot]:
-    result = []
+    result: list[EloSnapshot] = []
     for row in rows:
         d = dict(zip(columns, row, strict=True))
         result.append(

--- a/packages/pitlane-elo/src/pitlane_elo/snapshots.py
+++ b/packages/pitlane-elo/src/pitlane_elo/snapshots.py
@@ -215,9 +215,7 @@ def build_snapshots(
         store.ensure_schema()
 
         for race_entries in races:
-            rows, race_year = predict_snapshot_rows(
-                model, race_entries, session_type, current_year=current_year
-            )
+            rows, race_year = predict_snapshot_rows(model, race_entries, session_type, current_year=current_year)
             current_year = race_year
             model.process_race(race_entries)
 
@@ -227,7 +225,10 @@ def build_snapshots(
 
             store.write_snapshot_rows(rows)
             store.save_checkpoint(
-                model, race_year, rnd, session_type,
+                model,
+                race_year,
+                rnd,
+                session_type,
                 active_driver_ids=active_ids_cache[race_year],
             )
             total_rows += len(rows)
@@ -312,15 +313,17 @@ def add_race_snapshot(
             model.ratings = ratings
             model.k_factors = k_factors
 
-        snapshot_rows, _ = predict_snapshot_rows(
-            model, race_entries, session_type, current_year=cp_year
-        )
+        snapshot_rows, _ = predict_snapshot_rows(model, race_entries, session_type, current_year=cp_year)
         model.process_race(race_entries)
 
         active_ids = store.active_driver_ids(year, session_type)
         store.write_snapshot_rows(snapshot_rows)
         store.save_checkpoint(
-            model, year, round_num, session_type, active_driver_ids=active_ids,
+            model,
+            year,
+            round_num,
+            session_type,
+            active_driver_ids=active_ids,
         )
         con.commit()
 
@@ -381,7 +384,10 @@ def catchup_snapshots(
                 continue
 
             snapshot_rows, current_year = predict_snapshot_rows(
-                model, race_entries, session_type, current_year=current_year,
+                model,
+                race_entries,
+                session_type,
+                current_year=current_year,
             )
             model.process_race(race_entries)
 
@@ -390,7 +396,10 @@ def catchup_snapshots(
 
             store.write_snapshot_rows(snapshot_rows)
             store.save_checkpoint(
-                model, race_year, race_round, session_type,
+                model,
+                race_year,
+                race_round,
+                session_type,
                 active_driver_ids=active_ids_cache[race_year],
             )
             total_rows += len(snapshot_rows)

--- a/packages/pitlane-elo/src/pitlane_elo/snapshots.py
+++ b/packages/pitlane-elo/src/pitlane_elo/snapshots.py
@@ -1,21 +1,19 @@
-"""ELO snapshot persistence: pre-race ratings, win/podium probabilities, and actual results.
+"""ELO snapshot orchestration: pre-race ratings, win/podium probabilities, and actual results.
 
 Captures the state of the EndureElo model immediately before each race update
-and stores it to a DuckDB table (elo_snapshots). This allows querying predicted
-win/podium probabilities and comparing them to actual results without re-running
-from 1970 each time.
+and stores it to ``elo_snapshots``. Persistence lives in :class:`RatingsStore`;
+this module owns only the predict/update orchestration and the read helpers
+used by the CLI.
 
-Schema: elo_snapshots(year, round, session_type, driver_id, pre_race_rating,
-                       pre_race_k, win_probability, podium_probability,
-                       finish_position, dnf_category, created_at)
-
-Schema: elo_model_state(year, round, session_type, driver_id, rating, k_factor)
-        Full post-race model state enabling incremental snapshot additions.
+Snapshots are computed only for drivers who **started** the race — i.e. those
+with a non-null ``grid_position``. DNS entries are excluded from the win and
+podium probability inputs (they still flow to ``model.process_race`` where
+``_filter_entries`` handles mechanical DNFs for rating updates).
 """
 
 from __future__ import annotations
 
-import contextlib
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -24,14 +22,36 @@ import duckdb
 
 from pitlane_elo.config import ENDURE_ELO_CALIBRATED
 from pitlane_elo.data import (
-    RACE_COLS,
     RaceEntry,
     get_db_path,
     get_race_entries_range,
     group_entries_by_race,
-    order_race_entries,
 )
 from pitlane_elo.ratings.endure_elo import EndureElo
+from pitlane_elo.ratings_store import RatingsStore
+
+# ---------------------------------------------------------------------------
+# Retention policy
+# ---------------------------------------------------------------------------
+
+DEFAULT_STATE_RETENTION_YEARS = 5
+"""Drivers with no race_entries within this many years of the checkpoint are
+pruned from elo_model_state. Safe for endure-elo because initial_rating=0 and
+ratings decay geometrically toward 0, so re-initialization on return is
+equivalent to keeping the decayed value."""
+
+_RETENTION_ENV_VAR = "PITLANE_STATE_RETENTION_YEARS"
+
+
+def _resolve_retention_years(override: int | None) -> int:
+    """Explicit arg wins; otherwise env var; otherwise default."""
+    if override is not None:
+        return override
+    env = os.environ.get(_RETENTION_ENV_VAR, "").strip()
+    if env:
+        return int(env)
+    return DEFAULT_STATE_RETENTION_YEARS
+
 
 # ---------------------------------------------------------------------------
 # Dataclass
@@ -55,244 +75,51 @@ class EloSnapshot:
 
 
 # ---------------------------------------------------------------------------
-# Schema DDL
-# ---------------------------------------------------------------------------
-
-_CREATE_TABLE_SQL = """
-CREATE TABLE IF NOT EXISTS elo_snapshots (
-    year               INTEGER   NOT NULL,
-    round              INTEGER   NOT NULL,
-    session_type       VARCHAR   NOT NULL,
-    driver_id          VARCHAR   NOT NULL,
-    pre_race_rating    DOUBLE    NOT NULL,
-    pre_race_k         DOUBLE    NOT NULL,
-    win_probability    DOUBLE    NOT NULL,
-    podium_probability DOUBLE    NOT NULL DEFAULT 0.0,
-    finish_position    INTEGER,
-    dnf_category       VARCHAR   NOT NULL DEFAULT 'none',
-    created_at         TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    PRIMARY KEY (year, round, session_type, driver_id)
-)
-"""
-
-_ADD_PODIUM_COL_SQL = """
-ALTER TABLE elo_snapshots
-    ADD COLUMN podium_probability DOUBLE DEFAULT 0.0
-"""
-
-_CREATE_DRIVER_INDEX_SQL = """
-CREATE INDEX IF NOT EXISTS idx_elo_snapshots_driver
-    ON elo_snapshots (driver_id, year, round)
-"""
-
-_CREATE_RACE_INDEX_SQL = """
-CREATE INDEX IF NOT EXISTS idx_elo_snapshots_race
-    ON elo_snapshots (year, round, session_type)
-"""
-
-_UPSERT_SQL = """
-INSERT OR REPLACE INTO elo_snapshots
-    (year, round, session_type, driver_id, pre_race_rating, pre_race_k,
-     win_probability, podium_probability, finish_position, dnf_category, created_at)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-"""
-
-_CREATE_MODEL_STATE_SQL = """
-CREATE TABLE IF NOT EXISTS elo_model_state (
-    year         INTEGER NOT NULL,
-    round        INTEGER NOT NULL,
-    session_type VARCHAR NOT NULL,
-    driver_id    VARCHAR NOT NULL,
-    rating       DOUBLE  NOT NULL,
-    k_factor     DOUBLE  NOT NULL,
-    PRIMARY KEY (year, round, session_type, driver_id)
-)
-"""
-
-_CREATE_MODEL_STATE_INDEX_SQL = """
-CREATE INDEX IF NOT EXISTS idx_elo_model_state_race
-    ON elo_model_state (year, round, session_type)
-"""
-
-_UPSERT_STATE_SQL = """
-INSERT OR REPLACE INTO elo_model_state
-    (year, round, session_type, driver_id, rating, k_factor)
-VALUES (?, ?, ?, ?, ?, ?)
-"""
-
-# Drivers with no race_entries within this many years of the checkpoint are
-# omitted from elo_model_state. Safe for endure-elo because initial_rating=0
-# and ratings decay geometrically toward 0, so re-initialization on return is
-# equivalent to keeping the decayed value.
-STATE_RETENTION_YEARS = 10
-
-
-# ---------------------------------------------------------------------------
-# Schema management
+# Schema management (thin wrapper kept for backward compatibility)
 # ---------------------------------------------------------------------------
 
 
 def ensure_schema(con: duckdb.DuckDBPyConnection) -> None:
-    """Create elo_snapshots and elo_model_state tables/indexes if they do not exist. Idempotent."""
-    con.execute(_CREATE_TABLE_SQL)
-    with contextlib.suppress(duckdb.CatalogException):
-        con.execute(_ADD_PODIUM_COL_SQL)
-    con.execute(_CREATE_DRIVER_INDEX_SQL)
-    con.execute(_CREATE_RACE_INDEX_SQL)
-    con.execute(_CREATE_MODEL_STATE_SQL)
-    con.execute(_CREATE_MODEL_STATE_INDEX_SQL)
+    """Create elo_snapshots and elo_model_state tables/indexes. Idempotent."""
+    RatingsStore(con, retention_years=DEFAULT_STATE_RETENTION_YEARS).ensure_schema()
 
 
 # ---------------------------------------------------------------------------
-# Model-state helpers
+# Core single-race processing
 # ---------------------------------------------------------------------------
 
 
-def _active_driver_ids(
-    con: duckdb.DuckDBPyConnection,
-    year: int,
-    session_type: str,
-) -> set[str]:
-    """Return driver IDs with at least one entry in race_entries within STATE_RETENTION_YEARS of year."""
-    cursor = con.execute(
-        "SELECT DISTINCT driver_id FROM race_entries WHERE session_type = ? AND year >= ? AND year <= ?",
-        [session_type, year - STATE_RETENTION_YEARS, year],
-    )
-    return {row[0] for row in cursor.fetchall()}
+def _starters(entries: list[RaceEntry]) -> list[RaceEntry]:
+    """Entries with a non-null grid_position (drivers who started the race)."""
+    return [e for e in entries if e.get("grid_position") is not None]
 
 
-def _save_model_state(
-    con: duckdb.DuckDBPyConnection,
-    model: EndureElo,
-    year: int,
-    round_num: int,
-    session_type: str,
-    active_driver_ids: set[str] | None = None,
-) -> None:
-    """Persist model state after processing a race.
-
-    When active_driver_ids is provided, only those drivers are persisted,
-    pruning long-retired drivers from the checkpoint table.
-    """
-    rows = [
-        (year, round_num, session_type, driver_id, rating, model.k_factors[driver_id])
-        for driver_id, rating in model.ratings.items()
-        if active_driver_ids is None or driver_id in active_driver_ids
-    ]
-    con.executemany(_UPSERT_STATE_SQL, rows)
-
-
-def _load_model_state(
-    con: duckdb.DuckDBPyConnection,
-    year: int,
-    round_num: int,
-    session_type: str,
-) -> tuple[dict[str, float], dict[str, float]]:
-    """Load (ratings, k_factors) saved after the given race. Returns empty dicts if not found."""
-    cursor = con.execute(
-        "SELECT driver_id, rating, k_factor FROM elo_model_state WHERE year = ? AND round = ? AND session_type = ?",
-        [year, round_num, session_type],
-    )
-    rows = cursor.fetchall()
-    ratings: dict[str, float] = {}
-    k_factors: dict[str, float] = {}
-    for driver_id, rating, k_factor in rows:
-        ratings[driver_id] = rating
-        k_factors[driver_id] = k_factor
-    return ratings, k_factors
-
-
-def _latest_checkpoint(
-    con: duckdb.DuckDBPyConnection,
-    session_type: str,
-) -> tuple[int, int, str] | None:
-    """Return (year, round, session_type) of the most recently persisted model state, or None."""
-    try:
-        cursor = con.execute(
-            "SELECT year, round, session_type FROM elo_model_state "
-            "WHERE session_type = ? "
-            "ORDER BY year DESC, round DESC LIMIT 1",
-            [session_type],
-        )
-    except duckdb.CatalogException:
-        return None
-    row = cursor.fetchone()
-    if row is None:
-        return None
-    return (row[0], row[1], row[2])
-
-
-def _checkpoint_before(
-    con: duckdb.DuckDBPyConnection,
-    year: int,
-    round_num: int,
-    session_type: str,
-) -> tuple[int, int, str] | None:
-    """Return the most recent checkpoint STRICTLY before (year, round_num), or None."""
-    try:
-        cursor = con.execute(
-            "SELECT year, round, session_type FROM elo_model_state "
-            "WHERE session_type = ? "
-            "  AND (year < ? OR (year = ? AND round < ?)) "
-            "ORDER BY year DESC, round DESC LIMIT 1",
-            [session_type, year, year, round_num],
-        )
-    except duckdb.CatalogException:
-        return None
-    row = cursor.fetchone()
-    if row is None:
-        return None
-    return (row[0], row[1], row[2])
-
-
-def _gap_races_between(
-    con: duckdb.DuckDBPyConnection,
-    cp_year: int,
-    cp_round: int,
-    target_year: int,
-    target_round: int,
-    session_type: str,
-) -> list[tuple[int, int]]:
-    """Return (year, round) pairs in race_entries that fall between checkpoint and target (exclusive).
-
-    Uses race_entries as the source of truth — cancelled rounds that have no
-    entries are not returned, so they never block incremental adds.
-    """
-    cursor = con.execute(
-        "SELECT DISTINCT year, round FROM race_entries "
-        "WHERE session_type = ? "
-        "  AND (year > ? OR (year = ? AND round > ?)) "
-        "  AND (year < ? OR (year = ? AND round < ?)) "
-        "ORDER BY year, round",
-        [session_type, cp_year, cp_year, cp_round, target_year, target_year, target_round],
-    )
-    return [(r[0], r[1]) for r in cursor.fetchall()]
-
-
-# ---------------------------------------------------------------------------
-# Core single-race processing (shared between build, add, and catchup)
-# ---------------------------------------------------------------------------
-
-
-def _process_race(
+def predict_snapshot_rows(
     model: EndureElo,
     race_entries: list[RaceEntry],
     session_type: str,
     *,
     current_year: int | None,
 ) -> tuple[list[tuple], int]:
-    """Predict + update for one race. Returns (snapshot_rows, race_year).
+    """Compute pre-race snapshot rows for one race. Does not update the model.
 
-    Applies season decay when the race crosses a year boundary from current_year.
-    Does NOT write to the database — caller is responsible for persistence.
+    Applies season decay when the race crosses a year boundary from
+    ``current_year``. Only starters (``grid_position is not None``) are fed to
+    ``predict_win_probabilities`` / ``predict_podium_probabilities`` and only
+    starters produce snapshot rows. Returns ``([], race_year)`` when fewer
+    than two starters are present.
     """
     year = race_entries[0]["year"]
-    rnd = race_entries[0]["round"]
 
     if current_year is not None and year != current_year:
         model.apply_season_decay(year)
 
-    driver_ids = [e["driver_id"] for e in race_entries]
+    starters = _starters(race_entries)
+    if len(starters) < 2:
+        return [], year
+
+    rnd = starters[0]["round"]
+    driver_ids = [e["driver_id"] for e in starters]
 
     for d in driver_ids:
         model.get_rating(d)
@@ -305,32 +132,33 @@ def _process_race(
     podium_probs = model.predict_podium_probabilities(driver_ids)
     podium_map = dict(zip(driver_ids, podium_probs, strict=True))
 
-    finish_map = {e["driver_id"]: e.get("finish_position") for e in race_entries}
-    dnf_map = {e["driver_id"]: e.get("dnf_category") or "none" for e in race_entries}
+    finish_map = {e["driver_id"]: e.get("finish_position") for e in starters}
+    dnf_map = {e["driver_id"]: e.get("dnf_category") or "none" for e in starters}
 
-    rows: list[tuple] = []
-    for driver_id in driver_ids:
-        rows.append(
-            (
-                year,
-                rnd,
-                session_type,
-                driver_id,
-                pre_ratings[driver_id],
-                pre_ks[driver_id],
-                float(prob_map[driver_id]),
-                float(podium_map[driver_id]),
-                finish_map.get(driver_id),
-                dnf_map.get(driver_id, "none"),
-            )
+    rows: list[tuple] = [
+        (
+            year,
+            rnd,
+            session_type,
+            driver_id,
+            pre_ratings[driver_id],
+            pre_ks[driver_id],
+            float(prob_map[driver_id]),
+            float(podium_map[driver_id]),
+            finish_map.get(driver_id),
+            dnf_map.get(driver_id, "none"),
         )
-
-    model.process_race(race_entries)
+        for driver_id in driver_ids
+    ]
     return rows, year
 
 
+def _race_year_round(race_entries: list[RaceEntry]) -> tuple[int, int]:
+    return race_entries[0]["year"], race_entries[0]["round"]
+
+
 # ---------------------------------------------------------------------------
-# Write
+# Write orchestrators
 # ---------------------------------------------------------------------------
 
 
@@ -340,29 +168,32 @@ def build_snapshots(
     *,
     db_path: Path | None = None,
     session_type: str = "R",
+    retention_years: int | None = None,
 ) -> int:
-    """Compute and persist ELO snapshots for every race in [start_year, end_year].
+    """Compute and persist ELO snapshots for every race in ``[start_year, end_year]``.
 
-    Runs the calibrated EndureElo model in a predict-then-update loop.  For each
-    race, captures the pre-race ratings and win probabilities *before* calling
-    process_race(), then upserts a row per driver into elo_snapshots.
+    Runs the calibrated EndureElo model in a predict-then-update loop. For each
+    race captures the pre-race ratings and probabilities *before* updating, then
+    upserts a row per starter into elo_snapshots. Post-race model state is
+    persisted to elo_model_state, pruned by ``retention_years``.
 
-    Also persists the full model state after each race into elo_model_state,
-    enabling incremental single-race additions via add_race_snapshot().
-
-    Always re-runs from start_year because ELO ratings at race N depend on all
-    prior races. The upsert is idempotent: running twice produces the same row count.
+    Always re-runs from ``start_year`` because ELO ratings at race N depend on
+    all prior races. The upsert is idempotent.
 
     Args:
-        start_year: First season to process (used as warm-up + snapshot start).
+        start_year: First season to process (warm-up + snapshot start).
         end_year: Last season (inclusive).
-        db_path: Override the database path. Defaults to :func:`~pitlane_elo.data.get_db_path`.
-        session_type: Session type to process ("R" for race, "S" for sprint).
+        db_path: Override the database path.
+        session_type: "R" (race) or "S" (sprint).
+        retention_years: Years of history used to decide which drivers to keep
+            in checkpoints. Defaults to the ``PITLANE_STATE_RETENTION_YEARS``
+            env var, then :data:`DEFAULT_STATE_RETENTION_YEARS`.
 
     Returns:
         Number of snapshot rows written.
     """
     path = db_path or get_db_path()
+    retention = _resolve_retention_years(retention_years)
 
     all_entries = get_race_entries_range(start_year, end_year, db_path=path)
     if not all_entries:
@@ -380,17 +211,25 @@ def build_snapshots(
     active_ids_cache: dict[int, set[str]] = {}
 
     with duckdb.connect(str(path)) as con:
-        ensure_schema(con)
+        store = RatingsStore(con, retention_years=retention)
+        store.ensure_schema()
 
         for race_entries in races:
-            rows, race_year = _process_race(model, race_entries, session_type, current_year=current_year)
+            rows, race_year = predict_snapshot_rows(
+                model, race_entries, session_type, current_year=current_year
+            )
             current_year = race_year
+            model.process_race(race_entries)
 
+            _, rnd = _race_year_round(race_entries)
             if race_year not in active_ids_cache:
-                active_ids_cache[race_year] = _active_driver_ids(con, race_year, session_type)
-            rnd = race_entries[0]["round"]
-            con.executemany(_UPSERT_SQL, rows)
-            _save_model_state(con, model, race_year, rnd, session_type, active_ids_cache[race_year])
+                active_ids_cache[race_year] = store.active_driver_ids(race_year, session_type)
+
+            store.write_snapshot_rows(rows)
+            store.save_checkpoint(
+                model, race_year, rnd, session_type,
+                active_driver_ids=active_ids_cache[race_year],
+            )
             total_rows += len(rows)
 
         con.commit()
@@ -404,6 +243,7 @@ def add_race_snapshot(
     *,
     session_type: str = "R",
     db_path: Path | None = None,
+    retention_years: int | None = None,
 ) -> int:
     """Incrementally add one race to the snapshot without re-running history.
 
@@ -411,33 +251,20 @@ def add_race_snapshot(
     probabilities, updates ratings, and persists both the snapshot rows and
     the updated model state.
 
-    Requires elo_model_state to contain a checkpoint immediately before
-    (year, round_num). Raises click.ClickException with actionable guidance
-    when the prerequisite state is missing.
-
-    Cancelled races — rounds that have no rows in race_entries — are silently
-    skipped when checking for gaps, so adding a race after cancellations works
-    without any special flags.
-
-    Args:
-        year: Season year of the race to add.
-        round_num: Round number of the race to add.
-        session_type: Session type ("R" or "S").
-        db_path: Override the database path.
-
-    Returns:
-        Number of snapshot rows written (one per driver).
+    Cancelled races — rounds with no rows in race_entries — are silently
+    skipped when checking for gaps.
 
     Raises:
         click.ClickException: If prerequisites are not met.
     """
     path = db_path or get_db_path()
+    retention = _resolve_retention_years(retention_years)
 
     with duckdb.connect(str(path)) as con:
-        ensure_schema(con)
+        store = RatingsStore(con, retention_years=retention)
+        store.ensure_schema()
 
-        # Check prerequisites before touching race_entries
-        latest = _latest_checkpoint(con, session_type)
+        latest = store.latest_checkpoint(session_type)
         if latest is None:
             raise click.ClickException(
                 f"No model state found for session_type={session_type!r}. "
@@ -445,8 +272,6 @@ def add_race_snapshot(
             )
 
         latest_year, latest_round, _ = latest
-
-        # Reject adding a race that is strictly before the latest checkpoint (backwards add)
         if (year, round_num) < (latest_year, latest_round):
             raise click.ClickException(
                 f"{year} R{round_num} is before the latest checkpoint "
@@ -454,65 +279,49 @@ def add_race_snapshot(
                 "Use `pitlane-elo snapshot` to replay from scratch."
             )
 
-        # For both a fresh forward add and an idempotent re-add of the latest race,
-        # replay from the checkpoint strictly BEFORE the target race.
-        prior = _checkpoint_before(con, year, round_num, session_type)
+        prior = store.checkpoint_before(year, round_num, session_type)
         if prior is None:
-            # Target is the very first race ever processed; replay from empty state
             cp_year: int | None = None
             cp_round: int | None = None
         else:
             cp_year, cp_round, _ = prior
 
-        # Reject skipping real (non-cancelled) races between prior checkpoint and target
         if cp_year is not None and cp_round is not None:
-            gaps = _gap_races_between(con, cp_year, cp_round, year, round_num, session_type)
+            gaps = store.gap_races_between(cp_year, cp_round, year, round_num, session_type)
             if gaps:
                 gap_str = ", ".join(f"{y} R{r}" for y, r in gaps)
                 raise click.ClickException(
-                    f"Cannot add {year} R{round_num}: unprocessed races exist before it: {gap_str}. "
-                    "Add them in order or run `pitlane-elo snapshot-catchup`."
+                    f"Cannot add {year} R{round_num}: unprocessed races exist before it: "
+                    f"{gap_str}. Add them in order or run `pitlane-elo snapshot-catchup`."
                 )
 
-        # Load race entries for the target race
         try:
-            cursor = con.execute(
-                f"SELECT {RACE_COLS} FROM race_entries "
-                "WHERE year = ? AND round = ? AND session_type = ? "
-                "ORDER BY driver_id",
-                [year, round_num, session_type],
-            )
-            entry_rows = cursor.fetchall()
-            columns = [desc[0] for desc in cursor.description]
+            race_entries = store.read_race_entries(year, round_num, session_type)
         except duckdb.CatalogException as err:
             raise click.ClickException("race_entries table not found. Check your database path.") from err
 
-        if not entry_rows:
+        if not race_entries:
             raise click.ClickException(
                 f"No race entries found for {year} R{round_num} ({session_type}). "
                 "Verify the race exists in race_entries."
             )
 
-        race_entries: list[RaceEntry] = [
-            dict(zip(columns, row, strict=True))
-            for row in entry_rows  # type: ignore[misc]
-        ]
-        race_entries = order_race_entries(race_entries)
-
-        # Hydrate model from the prior checkpoint (or start empty for the very first race)
         model = EndureElo(ENDURE_ELO_CALIBRATED)
         if cp_year is not None and cp_round is not None:
-            ratings, k_factors = _load_model_state(con, cp_year, cp_round, session_type)
+            ratings, k_factors = store.load_checkpoint(cp_year, cp_round, session_type)
             model.ratings = ratings
             model.k_factors = k_factors
 
-        # Process the race
-        snapshot_rows, _ = _process_race(model, race_entries, session_type, current_year=cp_year)
+        snapshot_rows, _ = predict_snapshot_rows(
+            model, race_entries, session_type, current_year=cp_year
+        )
+        model.process_race(race_entries)
 
-        # Persist results
-        active_ids = _active_driver_ids(con, year, session_type)
-        con.executemany(_UPSERT_SQL, snapshot_rows)
-        _save_model_state(con, model, year, round_num, session_type, active_ids)
+        active_ids = store.active_driver_ids(year, session_type)
+        store.write_snapshot_rows(snapshot_rows)
+        store.save_checkpoint(
+            model, year, round_num, session_type, active_driver_ids=active_ids,
+        )
         con.commit()
 
     return len(snapshot_rows)
@@ -522,33 +331,26 @@ def catchup_snapshots(
     *,
     session_type: str = "R",
     db_path: Path | None = None,
+    retention_years: int | None = None,
 ) -> int:
     """Add every race in race_entries that has no model-state checkpoint yet.
 
     Finds the latest checkpoint in elo_model_state, then processes all
-    subsequent races in race_entries in chronological order. Cancelled
-    rounds (no entries in race_entries) are naturally skipped.
-
-    Requires at least one prior checkpoint (i.e. `pitlane-elo snapshot` must
-    have been run at least once).
-
-    Args:
-        session_type: Session type ("R" or "S").
-        db_path: Override the database path.
-
-    Returns:
-        Total number of snapshot rows written across all newly added races.
+    subsequent races in chronological order. Cancelled rounds (no entries in
+    race_entries) are naturally skipped.
 
     Raises:
         click.ClickException: If no prior checkpoint exists.
     """
     path = db_path or get_db_path()
+    retention = _resolve_retention_years(retention_years)
     total_rows = 0
 
     with duckdb.connect(str(path)) as con:
-        ensure_schema(con)
+        store = RatingsStore(con, retention_years=retention)
+        store.ensure_schema()
 
-        checkpoint = _latest_checkpoint(con, session_type)
+        checkpoint = store.latest_checkpoint(session_type)
         if checkpoint is None:
             raise click.ClickException(
                 f"No model state found for session_type={session_type!r}. "
@@ -557,24 +359,15 @@ def catchup_snapshots(
 
         cp_year, cp_round, _ = checkpoint
 
-        # Find all races in race_entries beyond the checkpoint
         try:
-            cursor = con.execute(
-                "SELECT DISTINCT year, round FROM race_entries "
-                "WHERE session_type = ? "
-                "  AND (year > ? OR (year = ? AND round > ?)) "
-                "ORDER BY year, round",
-                [session_type, cp_year, cp_year, cp_round],
-            )
-            pending = cursor.fetchall()
+            pending = store.pending_races_after_checkpoint(cp_year, cp_round, session_type)
         except duckdb.CatalogException as err:
             raise click.ClickException("race_entries table not found. Check your database path.") from err
 
         if not pending:
             return 0
 
-        # Load model from checkpoint once, then process races sequentially
-        ratings, k_factors = _load_model_state(con, cp_year, cp_round, session_type)
+        ratings, k_factors = store.load_checkpoint(cp_year, cp_round, session_type)
         model = EndureElo(ENDURE_ELO_CALIBRATED)
         model.ratings = ratings
         model.k_factors = k_factors
@@ -583,26 +376,23 @@ def catchup_snapshots(
         active_ids_cache: dict[int, set[str]] = {}
 
         for race_year, race_round in pending:
-            cursor = con.execute(
-                f"SELECT {RACE_COLS} FROM race_entries "
-                "WHERE year = ? AND round = ? AND session_type = ? ORDER BY driver_id",
-                [race_year, race_round, session_type],
-            )
-            entry_rows = cursor.fetchall()
-            if not entry_rows:
+            race_entries = store.read_race_entries(race_year, race_round, session_type)
+            if not race_entries:
                 continue
-            columns = [desc[0] for desc in cursor.description]
-            race_entries: list[RaceEntry] = [
-                dict(zip(columns, row, strict=True))
-                for row in entry_rows  # type: ignore[misc]
-            ]
-            race_entries = order_race_entries(race_entries)
 
-            snapshot_rows, current_year = _process_race(model, race_entries, session_type, current_year=current_year)
+            snapshot_rows, current_year = predict_snapshot_rows(
+                model, race_entries, session_type, current_year=current_year,
+            )
+            model.process_race(race_entries)
+
             if race_year not in active_ids_cache:
-                active_ids_cache[race_year] = _active_driver_ids(con, race_year, session_type)
-            con.executemany(_UPSERT_SQL, snapshot_rows)
-            _save_model_state(con, model, race_year, race_round, session_type, active_ids_cache[race_year])
+                active_ids_cache[race_year] = store.active_driver_ids(race_year, session_type)
+
+            store.write_snapshot_rows(snapshot_rows)
+            store.save_checkpoint(
+                model, race_year, race_round, session_type,
+                active_driver_ids=active_ids_cache[race_year],
+            )
             total_rows += len(snapshot_rows)
 
         con.commit()
@@ -648,17 +438,7 @@ def get_race_snapshot(
     session_type: str = "R",
     db_path: Path | None = None,
 ) -> list[EloSnapshot]:
-    """Return all driver snapshots for one race, sorted by win_probability DESC.
-
-    Args:
-        year: Season year.
-        round_num: Race round number.
-        session_type: "R" for race, "S" for sprint.
-        db_path: Override the database path.
-
-    Returns:
-        List of EloSnapshot objects, or empty list if no data found.
-    """
+    """All driver snapshots for one race, sorted by win_probability DESC."""
     path = db_path or get_db_path()
     if not path.exists():
         return []
@@ -672,7 +452,6 @@ def get_race_snapshot(
         try:
             cursor = con.execute(sql, [year, round_num, session_type])
         except duckdb.CatalogException:
-            # Table doesn't exist yet — user hasn't run snapshot command
             return []
         rows = cursor.fetchall()
         if not rows:
@@ -689,19 +468,7 @@ def get_driver_rating_history(
     session_type: str = "R",
     db_path: Path | None = None,
 ) -> list[EloSnapshot]:
-    """Return all snapshot rows for one driver in chronological order.
-
-    Args:
-        driver_id: Ergast driver ID slug (e.g. "max_verstappen").
-        start_year: First season to include.
-        end_year: Last season (inclusive).
-        session_type: "R" for race, "S" for sprint.
-        db_path: Override the database path.
-
-    Returns:
-        List of EloSnapshot objects in ascending (year, round) order,
-        or empty list if no data found.
-    """
+    """All snapshot rows for one driver in chronological order."""
     path = db_path or get_db_path()
     if not path.exists():
         return []
@@ -724,11 +491,13 @@ def get_driver_rating_history(
 
 
 __all__ = [
+    "DEFAULT_STATE_RETENTION_YEARS",
     "EloSnapshot",
-    "ensure_schema",
-    "build_snapshots",
     "add_race_snapshot",
+    "build_snapshots",
     "catchup_snapshots",
-    "get_race_snapshot",
+    "ensure_schema",
     "get_driver_rating_history",
+    "get_race_snapshot",
+    "predict_snapshot_rows",
 ]

--- a/packages/pitlane-elo/tests/test_snapshots.py
+++ b/packages/pitlane-elo/tests/test_snapshots.py
@@ -7,7 +7,9 @@ from pathlib import Path
 import duckdb
 import pytest
 from pitlane_elo.snapshots import (
+    DEFAULT_STATE_RETENTION_YEARS,
     EloSnapshot,
+    _resolve_retention_years,
     add_race_snapshot,
     build_snapshots,
     catchup_snapshots,
@@ -332,7 +334,7 @@ class TestModelStatePruning:
         finally:
             con.close()
 
-        build_snapshots(2000, 2012, db_path=tmp_db)
+        build_snapshots(2000, 2012, db_path=tmp_db, retention_years=10)
 
         with duckdb.connect(str(tmp_db), read_only=True) as con:
             # retired_driver must appear in 2000 checkpoints (within retention window)
@@ -377,7 +379,7 @@ class TestModelStatePruning:
         finally:
             con.close()
 
-        build_snapshots(2014, 2020, db_path=tmp_db)
+        build_snapshots(2014, 2020, db_path=tmp_db, retention_years=10)
 
         with duckdb.connect(str(tmp_db), read_only=True) as con:
             # driver_a raced in 2014; in 2019 checkpoint they are 5 years inactive — still within window
@@ -608,3 +610,128 @@ class TestCatchupSnapshots:
 
         with pytest.raises(click.ClickException, match="snapshot"):
             catchup_snapshots(db_path=tmp_db)
+
+
+# ---------------------------------------------------------------------------
+# TestStarterFilter — only drivers who started appear in snapshot rows
+# ---------------------------------------------------------------------------
+
+
+class TestStarterFilter:
+    def _insert_race(
+        self,
+        con: duckdb.DuckDBPyConnection,
+        year: int,
+        rnd: int,
+        rows: list[tuple[str, int | None, int | None]],
+    ) -> None:
+        for driver_id, grid, finish in rows:
+            con.execute(
+                """INSERT INTO race_entries
+                   (year, round, session_type, driver_id, team,
+                    grid_position, finish_position, laps_completed, status,
+                    dnf_category, is_wet_race, is_street_circuit)
+                   VALUES (?, ?, 'R', ?, 'T', ?, ?, 57, 'Finished', 'none', false, false)""",
+                [year, rnd, driver_id, grid, finish],
+            )
+
+    def test_dns_drivers_excluded_from_snapshots(self, tmp_db: Path) -> None:
+        with duckdb.connect(str(tmp_db)) as con:
+            self._insert_race(
+                con,
+                2024,
+                1,
+                [
+                    ("driver_a", 1, 1),
+                    ("driver_b", 2, 2),
+                    ("driver_c", 3, 3),
+                    ("dns_driver", None, None),  # DNS — qualified-out / did not start
+                ],
+            )
+            con.commit()
+
+        n = build_snapshots(2024, 2024, db_path=tmp_db, retention_years=10)
+
+        assert n == 3, "DNS driver must not produce a snapshot row"
+        with duckdb.connect(str(tmp_db), read_only=True) as con:
+            ids = {row[0] for row in con.execute("SELECT driver_id FROM elo_snapshots").fetchall()}
+        assert ids == {"driver_a", "driver_b", "driver_c"}
+        assert "dns_driver" not in ids
+
+    def test_probabilities_sum_to_one_with_dns_present(self, tmp_db: Path) -> None:
+        """Win probabilities must sum to 1 over STARTERS only — DNS should not dilute."""
+        with duckdb.connect(str(tmp_db)) as con:
+            self._insert_race(
+                con,
+                2024,
+                1,
+                [
+                    ("driver_a", 1, 1),
+                    ("driver_b", 2, 2),
+                    ("driver_c", 3, 3),
+                    ("dns_driver", None, None),
+                ],
+            )
+            con.commit()
+
+        build_snapshots(2024, 2024, db_path=tmp_db, retention_years=10)
+        with duckdb.connect(str(tmp_db), read_only=True) as con:
+            total = con.execute("SELECT SUM(win_probability) FROM elo_snapshots").fetchone()[0]
+        assert abs(total - 1.0) < 1e-9
+
+
+# ---------------------------------------------------------------------------
+# TestRetentionResolution — explicit arg > env var > default
+# ---------------------------------------------------------------------------
+
+
+class TestRetentionResolution:
+    def test_default_is_five(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("PITLANE_STATE_RETENTION_YEARS", raising=False)
+        assert DEFAULT_STATE_RETENTION_YEARS == 5
+        assert _resolve_retention_years(None) == 5
+
+    def test_env_var_overrides_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PITLANE_STATE_RETENTION_YEARS", "7")
+        assert _resolve_retention_years(None) == 7
+
+    def test_explicit_arg_beats_env_var(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("PITLANE_STATE_RETENTION_YEARS", "7")
+        assert _resolve_retention_years(3) == 3
+
+    def test_retention_param_prunes_state(self, tmp_db: Path) -> None:
+        """With retention_years=3, a driver inactive for >3 years must be pruned."""
+        with duckdb.connect(str(tmp_db)) as con:
+            # old_driver: only in 2020. active drivers race every year.
+            for driver_id, grid, finish in [("old_driver", 1, 1), ("active_a", 2, 2), ("active_b", 3, 3)]:
+                con.execute(
+                    """INSERT INTO race_entries
+                       (year, round, session_type, driver_id, team, grid_position, finish_position,
+                        laps_completed, status, dnf_category, is_wet_race, is_street_circuit)
+                       VALUES (2020, 1, 'R', ?, 'T', ?, ?, 57, 'Finished', 'none', false, false)""",
+                    [driver_id, grid, finish],
+                )
+            for year in (2021, 2022, 2023, 2024, 2025):
+                for driver_id, grid, finish in [("active_a", 1, 1), ("active_b", 2, 2)]:
+                    con.execute(
+                        """INSERT INTO race_entries
+                           (year, round, session_type, driver_id, team, grid_position, finish_position,
+                            laps_completed, status, dnf_category, is_wet_race, is_street_circuit)
+                           VALUES (?, 1, 'R', ?, 'T', ?, ?, 57, 'Finished', 'none', false, false)""",
+                        [year, driver_id, grid, finish],
+                    )
+            con.commit()
+
+        build_snapshots(2020, 2025, db_path=tmp_db, retention_years=3)
+
+        with duckdb.connect(str(tmp_db), read_only=True) as con:
+            # 2025 is 5 years after old_driver's only race — beyond 3-year retention
+            count_2025 = con.execute(
+                "SELECT COUNT(*) FROM elo_model_state WHERE driver_id = 'old_driver' AND year = 2025"
+            ).fetchone()[0]
+            # 2022 is 2 years after — within 3-year window
+            count_2022 = con.execute(
+                "SELECT COUNT(*) FROM elo_model_state WHERE driver_id = 'old_driver' AND year = 2022"
+            ).fetchone()[0]
+        assert count_2025 == 0, "old_driver must be pruned by 2025 with retention=3"
+        assert count_2022 > 0, "old_driver must remain in 2022 with retention=3"


### PR DESCRIPTION
## Summary

- Extracts DuckDB I/O from `snapshots.py` into a new `RatingsStore` class, making `build`/`add`/`catchup` thin orchestrators over a pure predict step
- Excludes DNS entries (`grid_position IS NULL`) from `_inclusion_exclusion` inputs so win/podium probabilities are computed only over drivers who actually started the race
- Makes `STATE_RETENTION_YEARS` configurable via function arg, `PITLANE_STATE_RETENTION_YEARS` env var, and new `--retention-years` CLI flag (default lowered from 10 → 5)
- Drops stale `elo_snapshots` and `elo_model_state` tables ahead of rebuilding with the refactored pipeline

## Test plan

- [x] Run `pitlane-elo snapshot` and confirm snapshots rebuild cleanly
- [x] Run `pitlane-elo snapshot-add` for a single race and verify ~1s incremental add
- [x] Run `pitlane-elo snapshot-catchup` and confirm it picks up only unprocessed races
- [x] Verify win probabilities for a race with DNS entries sum to ~1.0 across starters only
- [x] Run existing test suite: `uv run pytest packages/pitlane-elo/tests/test_snapshots.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)