### PR TITLE
feat: GitHub Action to auto-update F1 Parquet data

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -30,11 +30,15 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Get week stamp for cache key
+        id: week
+        run: echo "key=$(date -u +%Y-W%V)" >> "$GITHUB_OUTPUT"
+
       - name: Cache FastF1 data
         uses: actions/cache@v4
         with:
           path: ~/.pitlane/cache/fastf1
-          key: fastf1-${{ runner.os }}-${{ github.run_id }}
+          key: fastf1-${{ runner.os }}-${{ steps.week.outputs.key }}
           restore-keys: |
             fastf1-${{ runner.os }}-
 
@@ -43,18 +47,24 @@ jobs:
 
       - name: Update ELO data (race entries + qualifying entries)
         working-directory: packages/pitlane-agent
+        env:
+          INPUT_YEAR: ${{ inputs.year }}
+          INPUT_FORCE: ${{ inputs.force }}
         run: |
           ARGS=""
-          if [ -n "${{ inputs.year }}" ]; then ARGS="$ARGS --year ${{ inputs.year }}"; fi
-          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          if [ -n "$INPUT_YEAR" ]; then ARGS="$ARGS --year $INPUT_YEAR"; fi
+          if [ "$INPUT_FORCE" = "true" ]; then ARGS="$ARGS --force"; fi
           uv run python scripts/update_elo_data.py $ARGS
 
       - name: Update session stats
         working-directory: packages/pitlane-agent
+        env:
+          INPUT_YEAR: ${{ inputs.year }}
+          INPUT_FORCE: ${{ inputs.force }}
         run: |
           ARGS="--no-telemetry"
-          if [ -n "${{ inputs.year }}" ]; then ARGS="$ARGS --year ${{ inputs.year }}"; fi
-          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          if [ -n "$INPUT_YEAR" ]; then ARGS="$ARGS --year $INPUT_YEAR"; fi
+          if [ "$INPUT_FORCE" = "true" ]; then ARGS="$ARGS --force"; fi
           uv run python scripts/update_stats.py $ARGS
 
       - name: Update ELO snapshots

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -51,10 +51,10 @@ jobs:
           INPUT_YEAR: ${{ inputs.year }}
           INPUT_FORCE: ${{ inputs.force }}
         run: |
-          ARGS=""
-          if [ -n "$INPUT_YEAR" ]; then ARGS="$ARGS --year $INPUT_YEAR"; fi
-          if [ "$INPUT_FORCE" = "true" ]; then ARGS="$ARGS --force"; fi
-          uv run python scripts/update_elo_data.py $ARGS
+          ARGS=()
+          if [ -n "$INPUT_YEAR" ]; then ARGS+=(--year "$INPUT_YEAR"); fi
+          if [ "$INPUT_FORCE" = "true" ]; then ARGS+=(--force); fi
+          uv run python scripts/update_elo_data.py "${ARGS[@]}"
 
       - name: Update session stats
         working-directory: packages/pitlane-agent
@@ -62,10 +62,10 @@ jobs:
           INPUT_YEAR: ${{ inputs.year }}
           INPUT_FORCE: ${{ inputs.force }}
         run: |
-          ARGS="--no-telemetry"
-          if [ -n "$INPUT_YEAR" ]; then ARGS="$ARGS --year $INPUT_YEAR"; fi
-          if [ "$INPUT_FORCE" = "true" ]; then ARGS="$ARGS --force"; fi
-          uv run python scripts/update_stats.py $ARGS
+          ARGS=(--no-telemetry)
+          if [ -n "$INPUT_YEAR" ]; then ARGS+=(--year "$INPUT_YEAR"); fi
+          if [ "$INPUT_FORCE" = "true" ]; then ARGS+=(--force); fi
+          uv run python scripts/update_stats.py "${ARGS[@]}"
 
       - name: Update ELO snapshots
         run: uv run pitlane-elo snapshot-catchup
@@ -83,4 +83,4 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add packages/pitlane-agent/src/pitlane_agent/data/
           git commit -m "data: update F1 Parquet data [skip ci]"
-          git push
+          git push origin HEAD:${{ github.ref_name }}

--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -1,0 +1,76 @@
+name: Update F1 Data
+
+on:
+  schedule:
+    - cron: "0 8 * * 1" # Every Monday at 08:00 UTC (day after Sunday race)
+  workflow_dispatch:
+    inputs:
+      year:
+        description: "F1 season year (e.g. 2026); leave blank to auto-detect"
+        required: false
+        default: ""
+      force:
+        description: "Reprocess rounds already stored in Parquet files"
+        required: false
+        type: boolean
+        default: false
+
+jobs:
+  update-data:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Cache FastF1 data
+        uses: actions/cache@v4
+        with:
+          path: ~/.pitlane/cache/fastf1
+          key: fastf1-${{ runner.os }}-${{ github.run_id }}
+          restore-keys: |
+            fastf1-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: uv sync --all-packages
+
+      - name: Update ELO data (race entries + qualifying entries)
+        working-directory: packages/pitlane-agent
+        run: |
+          ARGS=""
+          if [ -n "${{ inputs.year }}" ]; then ARGS="$ARGS --year ${{ inputs.year }}"; fi
+          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          uv run python scripts/update_elo_data.py $ARGS
+
+      - name: Update session stats
+        working-directory: packages/pitlane-agent
+        run: |
+          ARGS="--no-telemetry"
+          if [ -n "${{ inputs.year }}" ]; then ARGS="$ARGS --year ${{ inputs.year }}"; fi
+          if [ "${{ inputs.force }}" = "true" ]; then ARGS="$ARGS --force"; fi
+          uv run python scripts/update_stats.py $ARGS
+
+      - name: Update ELO snapshots
+        run: uv run pitlane-elo snapshot-catchup
+
+      - name: Check for data changes
+        id: changes
+        run: |
+          git diff --quiet packages/pitlane-agent/src/pitlane_agent/data/ \
+            || echo "has_changes=true" >> "$GITHUB_OUTPUT"
+
+      - name: Commit and push updated Parquet files
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add packages/pitlane-agent/src/pitlane_agent/data/
+          git commit -m "data: update F1 Parquet data [skip ci]"
+          git push

--- a/packages/pitlane-agent/scripts/update_elo_data.py
+++ b/packages/pitlane-agent/scripts/update_elo_data.py
@@ -29,6 +29,7 @@ import click
 import fastf1
 import pandas as pd
 from fastf1.events import EventSchedule, Session
+from pitlane_agent.temporal.context import get_temporal_context
 from pitlane_agent.utils.elo_db import (
     QualifyingEntry,
     RaceEntry,
@@ -294,7 +295,7 @@ def _extract_qualifying_entries(
 
 
 @click.command()
-@click.option("--year", required=True, type=int, help="F1 season year (e.g. 2024)")
+@click.option("--year", required=False, default=None, type=int, help="F1 season year (default: current season)")
 @click.option(
     "--round",
     "round_number",
@@ -316,12 +317,14 @@ def _extract_qualifying_entries(
     help="Re-fetch and overwrite rounds already in data directory",
 )
 def update_elo_data(
-    year: int,
+    year: int | None,
     round_number: int | None,
     data_dir_str: str | None,
     force: bool,
 ) -> None:
     """Pre-compute per-driver ELO input data and upsert into Parquet files."""
+    if year is None:
+        year = get_temporal_context().current_season
     data_dir = Path(data_dir_str) if data_dir_str else get_data_dir()
     init_data_dir(data_dir)
     click.echo(f"Data dir: {data_dir}", err=True)

--- a/packages/pitlane-agent/scripts/update_stats.py
+++ b/packages/pitlane-agent/scripts/update_stats.py
@@ -19,6 +19,7 @@ import json
 import logging
 import sys
 import time
+from datetime import date
 from pathlib import Path
 
 import backoff
@@ -231,6 +232,11 @@ def update_stats(
         event_date = event["EventDate"]
         date_str = event_date.isoformat()[:10] if pd.notna(event_date) else None
         event_format = event.get("EventFormat", "conventional")
+
+        if pd.notna(event_date) and event_date.date() > date.today():
+            click.echo(f"  Skipping round {rn}: {event_name} (future event)", err=True)
+            skipped += 1
+            continue
 
         session_types = ["R"]
         if event_format in ("sprint", "sprint_shootout", "sprint_qualifying"):

--- a/packages/pitlane-agent/scripts/update_stats.py
+++ b/packages/pitlane-agent/scripts/update_stats.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python3
-"""Pre-compute per-session stats and write them to DuckDB.
+"""Pre-compute per-session stats and write them to Parquet files.
 
 Loads FastF1 session data for a given year (or specific round) and upserts
-the computed stats into the DuckDB database for fast retrieval by the
+the computed stats into session_stats.parquet for fast retrieval by the
 season-summary command.
 
 Usage:
+    python scripts/update_stats.py
     python scripts/update_stats.py --year 2024
     python scripts/update_stats.py --year 2024 --round 5
     python scripts/update_stats.py --year 2024 --no-telemetry
     python scripts/update_stats.py --year 2024 --force
-    python scripts/update_stats.py --year 2024 --db-path /custom/path.duckdb
 """
 
 from __future__ import annotations
@@ -25,6 +25,7 @@ import backoff
 import click
 import fastf1
 import pandas as pd
+from pitlane_agent.temporal.context import get_temporal_context
 from pitlane_agent.utils.fastf1_helpers import load_session, setup_fastf1_cache
 from pitlane_agent.utils.race_stats import (
     RaceSummaryStats,
@@ -148,7 +149,7 @@ def _process_session(
 
 
 @click.command()
-@click.option("--year", required=True, type=int, help="F1 season year (e.g. 2024)")
+@click.option("--year", required=False, default=None, type=int, help="F1 season year (default: current season)")
 @click.option(
     "--round",
     "round_number",
@@ -180,13 +181,15 @@ def _process_session(
     help="Re-compute and overwrite sessions already in DB",
 )
 def update_stats(
-    year: int,
+    year: int | None,
     round_number: int | None,
     data_dir_str: str | None,
     with_telemetry: bool,
     force: bool,
 ) -> None:
     """Pre-compute session stats and upsert them into Parquet files."""
+    if year is None:
+        year = get_temporal_context().current_season
     data_dir = Path(data_dir_str) if data_dir_str else get_data_dir()
     init_data_dir(data_dir)
     click.echo(f"Data dir: {data_dir}", err=True)

--- a/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
@@ -194,6 +194,7 @@ class RatingsStore:
             self.con.execute(
                 f"COPY (SELECT * FROM elo_snapshots WHERE year = {year}) TO '{p}' (FORMAT PARQUET, COMPRESSION ZSTD)"
             )
+        self._dirty_years.clear()
 
         model_state_path = self.data_dir / "elo_model_state.parquet"
         row_count = self.con.execute("SELECT COUNT(*) FROM elo_model_state").fetchone()[0]

--- a/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
+++ b/packages/pitlane-elo/src/pitlane_elo/ratings_store.py
@@ -154,6 +154,7 @@ class RatingsStore:
         self.con = con
         self.data_dir = data_dir
         self.retention_years = retention_years
+        self._dirty_years: set[int] = set()
 
     # ----- schema ---------------------------------------------------------
 
@@ -188,8 +189,7 @@ class RatingsStore:
         self.data_dir.mkdir(parents=True, exist_ok=True)
         (self.data_dir / "elo_snapshots").mkdir(parents=True, exist_ok=True)
 
-        years = [r[0] for r in self.con.execute("SELECT DISTINCT year FROM elo_snapshots ORDER BY year").fetchall()]
-        for year in years:
+        for year in sorted(self._dirty_years):
             p = self.data_dir / "elo_snapshots" / f"{year}.parquet"
             self.con.execute(
                 f"COPY (SELECT * FROM elo_snapshots WHERE year = {year}) TO '{p}' (FORMAT PARQUET, COMPRESSION ZSTD)"
@@ -315,6 +315,8 @@ class RatingsStore:
         if not rows:
             return
         self.con.executemany(_UPSERT_SNAPSHOT_SQL, rows)
+        for row in rows:
+            self._dirty_years.add(row.year)
 
     # ----- race-entries read ----------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/update-data.yml`: a weekly action (Monday 08:00 UTC) that runs the data pipeline and commits updated Parquet files back to the branch. Also supports `workflow_dispatch` with optional `year` and `force` inputs.
- Refactors `update_elo_data.py` and `update_stats.py` to make `--year` optional — both scripts now auto-detect the current season via `get_temporal_context().current_season` when no year is provided.

**Update order in the action:**
1. `update_elo_data.py` — race entries + qualifying entries
2. `update_stats.py --no-telemetry` — session stats (independent of #1)
3. `pitlane-elo snapshot-catchup` — ELO snapshots + model state (depends on #1)

All three scripts already have backfill logic that skips rounds already stored in Parquet, so the action is idempotent — re-running produces no new commit when everything is up to date. Data commits use `[skip ci]` to avoid re-triggering `pr-checks.yml`.

## Test plan

- [x] Trigger **Actions → Update F1 Data → Run workflow** with no inputs — confirm all 3 steps run and a data commit is pushed
- [x] Re-run the action — confirm "Already up to date" output and no new commit
- [x] Trigger with `year: 2024` and `force: true` — confirm `--year 2024 --force` is passed correctly
- [x] Run `python scripts/update_elo_data.py --help` and `update_stats.py --help` — confirm `--year` is listed as optional

🤖 Generated with [Claude Code](https://claude.com/claude-code)