### PR TITLE
chore: include pitlane-elo in version bump workflow

### DIFF
--- a/packages/pitlane-elo/pyproject.toml
+++ b/packages/pitlane-elo/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "pitlane-elo"
-version = "0.1.0"
+version = "0.4.6"
 description = "ELO rating models and story detection for F1"
 readme = "README.md"
 requires-python = ">=3.12,<3.15"

--- a/packages/pitlane-elo/src/pitlane_elo/__init__.py
+++ b/packages/pitlane-elo/src/pitlane_elo/__init__.py
@@ -1,5 +1,7 @@
 """ELO rating models and story detection for F1."""
 
+__version__ = "0.4.6"
+
 import os
 
 # workqueue is Numba's most portable threading backend and avoids TBB/OpenMP

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -2,12 +2,14 @@
 """
 Atomically bump version across all PitLane-AI packages.
 
-This script updates the version number in all 5 locations:
+This script updates the version number in all 7 locations:
 1. /pyproject.toml (root package)
 2. /packages/pitlane-agent/pyproject.toml
-3. /packages/pitlane-web/pyproject.toml
-4. /packages/pitlane-agent/src/pitlane_agent/__init__.py
-5. /packages/pitlane-web/src/pitlane_web/__init__.py
+3. /packages/pitlane-elo/pyproject.toml
+4. /packages/pitlane-web/pyproject.toml
+5. /packages/pitlane-agent/src/pitlane_agent/__init__.py
+6. /packages/pitlane-elo/src/pitlane_elo/__init__.py
+7. /packages/pitlane-web/src/pitlane_web/__init__.py
 
 Supports PEP 440 versioning including pre-release and local versions.
 
@@ -142,8 +144,10 @@ def bump_version(version: str) -> None:
     files_to_update: list[tuple[Path, callable]] = [
         (repo_root / "pyproject.toml", update_pyproject_toml),
         (repo_root / "packages/pitlane-agent/pyproject.toml", update_pyproject_toml),
+        (repo_root / "packages/pitlane-elo/pyproject.toml", update_pyproject_toml),
         (repo_root / "packages/pitlane-web/pyproject.toml", update_pyproject_toml),
         (repo_root / "packages/pitlane-agent/src/pitlane_agent/__init__.py", update_init_py),
+        (repo_root / "packages/pitlane-elo/src/pitlane_elo/__init__.py", update_init_py),
         (repo_root / "packages/pitlane-web/src/pitlane_web/__init__.py", update_init_py),
     ]
 


### PR DESCRIPTION
## Summary
- Adds `pitlane-elo/pyproject.toml` and `pitlane-elo/src/pitlane_elo/__init__.py` to `scripts/bump_version.py` so all three packages are bumped together on release
- Adds `__version__` to `pitlane-elo/__init__.py` to match the convention used by pitlane-agent and pitlane-web
- Syncs pitlane-elo version from 0.1.0 → 0.4.6 to align with the rest of the monorepo

## Test plan
- [x] Trigger the version bump workflow and confirm all 7 files are updated
- [x] Verify `pitlane-elo` pyproject.toml and `__init__.py` reflect the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)