### PR TITLE
feat: PitLane Studio — project setup, roadmap, and Phase 1 plans

### DIFF
--- a/.planning/PROJECT.md
+++ b/.planning/PROJECT.md
@@ -1,0 +1,87 @@
+# PitLane Studio
+
+## What This Is
+
+PitLane Studio is a web-based co-authoring interface for F1 journalism, built as a new `pitlane-studio` package inside the existing uv monorepo. It consumes the ELO signal data and FastF1 race telemetry already produced by pitlane-agent and pitlane-elo, and transforms them into structured narrative story angles, five-act race timelines, and plan-then-write prose drafts that can be exported to Substack. The user is the sole writer; this is a personal productivity tool, not a multi-tenant product.
+
+## Core Value
+
+Surface 4–6 data-grounded story angles from any race and guide the journalist through an outline-first drafting pipeline, so writing time goes entirely to voice, context, and quotes — not finding the story.
+
+## Requirements
+
+### Validated
+
+These capabilities already exist in the codebase and are the foundation the new interface builds on.
+
+- ✓ ELO rating engine (EndureElo + SpeedElo) — existing, tested
+- ✓ Story signal detection (`pitlane_elo/stories/signals.py`) — hot streaks, teammate shifts, slumps, ELO deltas
+- ✓ FastF1 data access — lap times, telemetry, tyre strategy, race control messages, standings, session info
+- ✓ Claude Agent SDK integration — the AI reasoning layer is wired up
+- ✓ Workspace management — `~/.pitlane/workspaces/<uuid>/` file-based state
+- ✓ FastAPI web server infrastructure — pitlane-web package pattern available to follow
+
+### Active
+
+- [ ] Story angle detection layer — maps race ELO signals + telemetry outputs to 4–6 narrative frames per race (e.g. "Dominant Tyre Management," "Comeback Narrative," "Strategic Gamble That Backfired")
+- [ ] Five-act race timeline spine — maps existing pitlane commands to Bouzarth et al.'s five dramatic acts: qualifying/grid (inciting incident), lap-1 chaos (complications), pit window (crisis), final stint (climax), championship implications (resolution)
+- [ ] Plan-then-write pipeline — outline approval step before any prose generation; AI generates beat-by-beat prose only after journalist approves structure
+- [ ] Structured co-authoring UI — story angle cards (select, not blank page); race timeline with draggable beats; beat-by-beat prose editor with placeholder hooks for journalist-only content (quotes, context, causal reasoning)
+- [ ] Substack export — unofficial Substack API integration with markdown copy/paste fallback when API is unavailable
+
+### Out of Scope
+
+- Character arc detection (Direction 5) — v2; angle detection covers the most important cases first
+- Multimodal chart pairing (Direction 6) — v2; manual chart insertion is sufficient for v1
+- Audience framing controls (Direction 7) — v2; single writing voice for now
+- Multi-user access, authentication — personal tool, no auth needed
+- Official Substack API — does not exist yet; unofficial API is best available option
+- Mobile UI — desktop web only
+
+## Context
+
+This project evolves the existing PitLane CLI/agent into a purpose-built writing interface. The research document (`pitlane-research-summary.md`) grounds the design in four papers:
+
+- **Wölker & Powell (2018)** — algorithmic sports content is credible; the journalist's differentiated value is context, causality, and interviews. Design consequence: always include structured placeholder hooks for human-only content.
+- **Bouzarth et al. (2021)** — five-act dramatic structure applies to sports analytics; named archetypes make data emotionally accessible. Design consequence: story angles are named narrative frames, not raw stats.
+- **Sánchez-López et al. (2025)** — effective tools encode journalist intent through structured choices, not free-text prompting. Design consequence: story angle cards + outline approval, not a chat box.
+- **Wang et al. (2025)** — LLMs degrade after the first 40–60% of long output; plan-then-write pipelines consistently outperform streaming full-text. Design consequence: never generate a full article in one pass.
+
+The existing ELO system design document (`docs/F1_ELO_Story_Detection_System_Design.md`) establishes that endure-Elo outperforms speed-Elo and the Bayesian model for prediction; this is the signal source for story angle detection.
+
+## Constraints
+
+- **Tech stack**: Python uv monorepo — new `pitlane-studio` package follows the same pattern as pitlane-web. No separate repo.
+- **Integration**: Must call into pitlane-agent and pitlane-elo packages; no duplicating data access or ELO logic.
+- **Export**: Substack is the publishing destination. Unofficial API is acceptable; markdown fallback is required.
+- **Scope**: Personal tool — no auth, no multi-tenancy, no SLA.
+- **Frontend**: Modern enough to support card-based selection UI and a structured editor; Jinja2 + HTMX or a lightweight SPA are both acceptable.
+
+## Key Decisions
+
+| Decision | Rationale | Outcome |
+|----------|-----------|---------|
+| Separate package (`pitlane-studio`) vs. extending pitlane-web | Co-authoring UI has a fundamentally different interaction model than the chat interface; mixing them creates a confusing product | — Pending |
+| Unofficial Substack API with markdown fallback | No official API exists; unofficial is best available; markdown fallback prevents publisher lock-in | — Pending |
+| v1 = 3 directions only (angle detection, plan-then-write, five-act) | Research doc explicitly prioritizes these; shipping fewer things lets the core loop get validated before adding audience framing, chart pairing, etc. | — Pending |
+| EndureElo as the signal source for story angles | Empirically outperforms speed-Elo and Bayesian model; already implemented and tested | ✓ Good |
+
+## Evolution
+
+This document evolves at phase transitions and milestone boundaries.
+
+**After each phase transition** (via `/gsd-transition`):
+1. Requirements invalidated? → Move to Out of Scope with reason
+2. Requirements validated? → Move to Validated with phase reference
+3. New requirements emerged? → Add to Active
+4. Decisions to log? → Add to Key Decisions
+5. "What This Is" still accurate? → Update if drifted
+
+**After each milestone** (via `/gsd-complete-milestone`):
+1. Full review of all sections
+2. Core Value check — still the right priority?
+3. Audit Out of Scope — reasons still valid?
+4. Update Context with current state
+
+---
+*Last updated: 2026-05-02 after initialization*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -107,4 +107,4 @@
 
 ---
 *Requirements defined: 2026-05-02*
-*Last updated: 2026-05-02 after initial definition*
+*Last updated: 2026-05-02 — traceability confirmed against ROADMAP.md*

--- a/.planning/REQUIREMENTS.md
+++ b/.planning/REQUIREMENTS.md
@@ -1,0 +1,110 @@
+# Requirements: PitLane Studio
+
+**Defined:** 2026-05-02
+**Core Value:** Surface 4–6 data-grounded story angles from any race and guide the journalist through an outline-first drafting pipeline, so writing time goes entirely to voice, context, and quotes — not finding the story.
+
+## v1 Requirements
+
+### Package & Infrastructure
+
+- [ ] **PKG-01**: Developer can install pitlane-studio as a uv workspace package alongside pitlane-agent and pitlane-elo (pyproject.toml, FastAPI skeleton, uvicorn entry point, `pitlane-studio` CLI)
+- [ ] **PKG-02**: pitlane-elo exposes a `studio_api` interface module with a cross-package integration test that calls `detect_stories()` with real data — not a mock
+- [ ] **PKG-03**: claude-agent-sdk is pinned to `<0.2.0` and any Jinja2 `| safe` template outputs are sanitized with `bleach.clean()`
+- [ ] **PKG-04**: User can persist article drafts across sessions via SQLite at `~/.pitlane/studio/articles.db` with status machine (`draft` → `outline_generated` → `outline_approved` → `published`)
+
+### Story Angle Detection
+
+- [ ] **ANGL-01**: User can load any completed race and receive 4–6 story angle candidates derived from ELO signals (SurpriseScore, ΔR̂, teammate ΔR̂ crossing, hot/cold streaks)
+- [ ] **ANGL-02**: Angle candidates are ranked by field-relative significance (top 2 per signal type) and filtered for novelty (suppress same driver + same signal type if it appeared in the prior 2 races)
+- [ ] **ANGL-03**: Driver crisis angles (slump, underperformance) are cross-checked against web search results for that race's DNF/retirement events before surfacing — FastF1 DNF classification is not used
+- [ ] **ANGL-04**: Angle generation is blocked with a user-facing message if race session data is less than 2 hours old or lap count is incomplete
+
+### Five-Act Race Timeline
+
+- [ ] **ACT-01**: System maps Bouzarth et al.'s five dramatic acts to specific pitlane-agent commands via static Python config (act 1: qualifying/grid → `session-info` + `position-changes`; act 2: lap-1 chaos → `race-control` + `position-changes`; act 3: pit window → `tyre-strategy` + `race-control`; act 4: final stint → `lap-times` + `position-changes`; act 5: implications → `standings`)
+- [ ] **ACT-02**: System fetches and caches act-specific data on race load; data is available as grounding context when generating outline and beat prose
+- [ ] **ACT-03**: User sees an always-visible five-act sidebar in the co-authoring UI showing act labels, mapped data sources, and key data points per act
+
+### Plan-Then-Write Pipeline
+
+- [ ] **PTW-01**: System generates a structured article outline (5 beat dicts: beat title, data anchors, suggested angle framing, placeholder types required) via a single non-streaming LLM call after user selects an angle
+- [ ] **PTW-02**: User must explicitly approve the outline before any beat prose is generated; the approval action is a hard gate — there is no way to skip it
+- [ ] **PTW-03**: After outline approval, system generates prose for each of the 5 beats via 5 separate streaming LLM calls (one per act/beat); the full approved outline is injected into every beat's prompt
+- [ ] **PTW-04**: Each generated beat contains enforced placeholder hooks for journalist-only content (at minimum: one quote placeholder, one contextual explanation placeholder, one causal reasoning placeholder per beat); the tool does not generate content to fill these slots
+
+### Co-Authoring UI
+
+- [ ] **UI-01**: User can select a race from a race selector, view 4–6 angle cards (each showing: angle name, signal type, confidence level, brief data rationale), and choose 1–2 angles to develop into an article
+- [ ] **UI-02**: User can read and edit each beat's AI-generated prose in a TipTap block editor, with placeholder hooks rendered as visually distinct unfilled blocks
+- [ ] **UI-03**: User can review the full 5-beat outline in a panel before prose generation begins, and can edit beat titles or data anchors before approving
+
+### Export
+
+- [ ] **XPRT-01**: User can copy a clean markdown export of the full article draft at any time, with placeholder hooks rendered as `[JOURNALIST: <type>]` markers visible in the output
+
+## v2 Requirements
+
+### Export
+
+- **XPRT-02**: Substack unofficial API draft export (POST to `/api/v1/drafts` with cookie auth; TipTap JSON payload)
+- **XPRT-03**: Substack export health check (validate cookie auth before showing export option; degrade to markdown if check fails)
+
+### Content Management
+
+- **CM-01**: Article draft list — user can see and resume all saved drafts per race
+- **CM-02**: Draggable beat reordering between acts in the timeline view
+
+### Writing Experience
+
+- **WE-01**: Audience framing control (casual fan / enthusiast / technical) adjusts prose depth across all beats
+- **WE-02**: Character arc detection — flag narratively significant multi-race driver arcs (comeback, consistent underperformance, gamble pattern)
+- **WE-03**: Multimodal pairing — auto-suggest which pitlane chart pairs with each narrative beat
+
+### Platform
+
+- **PLAT-01**: Live in-race mode — angle detection triggered by session data as race progresses
+
+## Out of Scope
+
+| Feature | Reason |
+|---------|--------|
+| Official Substack API | Does not exist |
+| One-shot full article generation | Violates Wang et al. quality findings; defeats plan-then-write purpose |
+| Chat box as primary interface | Sánchez-López: structured choices outperform open-ended prompting |
+| Auto-publish / direct publish | Always export to draft; journalist reviews before any post goes live |
+| Generic template library | Angles come from ELO data, not sports writing templates |
+| Multi-user access / authentication | Personal tool; no auth needed |
+| Mobile UI | Desktop web only |
+
+## Traceability
+
+| Requirement | Phase | Status |
+|-------------|-------|--------|
+| PKG-01 | Phase 1 | Pending |
+| PKG-02 | Phase 1 | Pending |
+| PKG-03 | Phase 1 | Pending |
+| PKG-04 | Phase 1 | Pending |
+| ANGL-01 | Phase 2 | Pending |
+| ANGL-02 | Phase 2 | Pending |
+| ANGL-03 | Phase 2 | Pending |
+| ANGL-04 | Phase 2 | Pending |
+| ACT-01 | Phase 2 | Pending |
+| ACT-02 | Phase 2 | Pending |
+| ACT-03 | Phase 3 | Pending |
+| PTW-01 | Phase 3 | Pending |
+| PTW-02 | Phase 3 | Pending |
+| PTW-03 | Phase 3 | Pending |
+| PTW-04 | Phase 3 | Pending |
+| UI-01 | Phase 3 | Pending |
+| UI-02 | Phase 3 | Pending |
+| UI-03 | Phase 3 | Pending |
+| XPRT-01 | Phase 3 | Pending |
+
+**Coverage:**
+- v1 requirements: 19 total
+- Mapped to phases: 19
+- Unmapped: 0 ✓
+
+---
+*Requirements defined: 2026-05-02*
+*Last updated: 2026-05-02 after initial definition*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -1,0 +1,99 @@
+# Roadmap: PitLane Studio
+
+**Project:** PitLane Studio
+**Milestone:** v1 — F1 journalism co-authoring interface
+**Created:** 2026-05-02
+**Granularity:** Standard (5–8 phases)
+
+---
+
+## Phases
+
+- [ ] **Phase 1: Package Scaffold + Prerequisites** - Install pitlane-studio into the monorepo, resolve inherited tech debt, and establish the SQLite article store as the foundation every downstream service depends on
+- [ ] **Phase 2: Story Angle Detection + Five-Act Data Layer** - Build AngleService with ranking, novelty, and DNF filters; build FiveActMapper; wire PKG-02 cross-package integration surface; validate all signal quality concerns before UI conceals them
+- [ ] **Phase 3: Plan-Then-Write Pipeline + Co-Authoring UI** - Build PipelineOrchestrator (outline → hard approval gate → per-beat SSE prose), FastAPI routes, and Svelte/TipTap frontend; integrate five-act sidebar and markdown export
+
+---
+
+## Phase Details
+
+### Phase 1: Package Scaffold + Prerequisites
+**Goal**: A developer can install `pitlane-studio` as a uv workspace package with a working FastAPI skeleton, a tested SQLite article store, a pinned SDK dependency, and sanitized template outputs — so all subsequent phases build on a clean, stable foundation
+**Depends on**: Nothing (first phase)
+**Requirements**: PKG-01, PKG-02, PKG-03, PKG-04
+**Success Criteria** (what must be TRUE):
+  1. `pitlane-studio` installs cleanly via `uv sync --all-packages` alongside pitlane-agent, pitlane-elo, and pitlane-web with no dependency conflicts
+  2. `pitlane-studio` CLI entry point starts a FastAPI/uvicorn server; health endpoint responds 200
+  3. `pitlane_elo.studio_api` module exists and exposes `detect_stories()`; a cross-package integration test calls it with real (non-mock) data and passes under `uv run --directory packages/pitlane-studio pytest`
+  4. `claude-agent-sdk` is pinned to `<0.2.0` in pyproject.toml and any Jinja2 `| safe` outputs pass through `bleach.clean()` — verifiable by code inspection and a unit test asserting sanitization
+  5. An article record can be created, transitioned through all four states (`draft` → `outline_generated` → `outline_approved` → `published`), and persisted at `~/.pitlane/studio/articles.db` — verified by a pytest integration test against a real SQLite file
+**Plans**: TBD
+
+### Phase 2: Story Angle Detection + Five-Act Data Layer
+**Goal**: The system surfaces 4–6 ranked, filtered, novel story angle candidates from any completed race using ELO signals, cross-checks driver crisis angles against actual DNF records, gates on data completeness, and has all five-act data fetched and cached — so angle quality is validated independently before the UI makes problems invisible
+**Depends on**: Phase 1
+**Requirements**: ANGL-01, ANGL-02, ANGL-03, ANGL-04, ACT-01, ACT-02
+**Success Criteria** (what must be TRUE):
+  1. Given a completed race, the system returns between 4 and 6 angle candidates derived from ELO signals (SurpriseScore, ΔR̂, teammate ΔR̂ crossing, hot/cold streaks) — verifiable via a pytest test against real 2025/2026 race data
+  2. Angle candidates are ranked by field-relative significance (top 2 per signal type) and the same driver+signal combination does not appear if it was surfaced in either of the prior 2 races — verifiable by a novelty filter unit test
+  3. A driver crisis angle (slump, underperformance) is suppressed and replaced with a user-facing message when a web search confirms the driver DNF/retired that race — FastF1 DNF classification is explicitly not used for this check
+  4. Attempting to load angle candidates for a race session less than 2 hours old or with an incomplete lap count returns a clear blocking message and generates no angle candidates
+  5. All five-act data (qualifying/grid, lap-1 chaos, pit window, final stint, championship implications) is fetched from pitlane-agent commands and cached on race load; each act's data is accessible as a Python dict keyed by act number — verifiable by a unit test against the static act→command config
+**Plans**: TBD
+
+### Phase 3: Plan-Then-Write Pipeline + Co-Authoring UI
+**Goal**: A journalist can select a race, choose an angle, review and approve a structured outline, receive beat-by-beat AI prose with enforced placeholder hooks, edit in a block editor, see the five-act sidebar, and copy a clean markdown export — so the complete writing workflow is usable end to end
+**Depends on**: Phase 2
+**Requirements**: ACT-03, PTW-01, PTW-02, PTW-03, PTW-04, UI-01, UI-02, UI-03, XPRT-01
+**Success Criteria** (what must be TRUE):
+  1. A journalist can open the UI, select a race from the race selector, and see 4–6 angle cards each showing angle name, signal type, confidence level, and a brief data rationale — without any blank page or free-text prompt
+  2. After selecting an angle, the journalist sees a 5-beat outline panel; can edit beat titles and data anchors; and must explicitly click an approve action before any prose is generated — there is no route to prose generation that bypasses this gate
+  3. After outline approval, prose for each of 5 beats is generated via 5 separate streaming LLM calls; each beat's prompt includes the full approved outline; the journalist can observe prose appearing beat by beat in the editor
+  4. Every generated beat contains at minimum one quote placeholder, one contextual explanation placeholder, and one causal reasoning placeholder rendered as visually distinct unfilled blocks in the TipTap editor — the tool generates no content to fill these slots
+  5. The always-visible five-act sidebar shows act labels, mapped pitlane-agent data sources, and key data points for each act throughout the drafting session
+  6. The journalist can click a copy/export action at any time and receive clean markdown with placeholder hooks rendered as `[JOURNALIST: <type>]` markers
+**Plans**: TBD
+**UI hint**: yes
+
+---
+
+## Progress Table
+
+| Phase | Plans Complete | Status | Completed |
+|-------|----------------|--------|-----------|
+| 1. Package Scaffold + Prerequisites | 0/? | Not started | - |
+| 2. Story Angle Detection + Five-Act Data Layer | 0/? | Not started | - |
+| 3. Plan-Then-Write Pipeline + Co-Authoring UI | 0/? | Not started | - |
+
+---
+
+## Coverage
+
+**v1 requirements:** 19 total
+**Mapped:** 19/19
+
+| Requirement | Phase |
+|-------------|-------|
+| PKG-01 | Phase 1 |
+| PKG-02 | Phase 1 |
+| PKG-03 | Phase 1 |
+| PKG-04 | Phase 1 |
+| ANGL-01 | Phase 2 |
+| ANGL-02 | Phase 2 |
+| ANGL-03 | Phase 2 |
+| ANGL-04 | Phase 2 |
+| ACT-01 | Phase 2 |
+| ACT-02 | Phase 2 |
+| ACT-03 | Phase 3 |
+| PTW-01 | Phase 3 |
+| PTW-02 | Phase 3 |
+| PTW-03 | Phase 3 |
+| PTW-04 | Phase 3 |
+| UI-01 | Phase 3 |
+| UI-02 | Phase 3 |
+| UI-03 | Phase 3 |
+| XPRT-01 | Phase 3 |
+
+---
+
+*Roadmap created: 2026-05-02*

--- a/.planning/ROADMAP.md
+++ b/.planning/ROADMAP.md
@@ -27,7 +27,11 @@
   3. `pitlane_elo.studio_api` module exists and exposes `detect_stories()`; a cross-package integration test calls it with real (non-mock) data and passes under `uv run --directory packages/pitlane-studio pytest`
   4. `claude-agent-sdk` is pinned to `<0.2.0` in pyproject.toml and any Jinja2 `| safe` outputs pass through `bleach.clean()` — verifiable by code inspection and a unit test asserting sanitization
   5. An article record can be created, transitioned through all four states (`draft` → `outline_generated` → `outline_approved` → `published`), and persisted at `~/.pitlane/studio/articles.db` — verified by a pytest integration test against a real SQLite file
-**Plans**: TBD
+**Plans**: 4 plans
+  - [ ] 01-01-PLAN.md — Wave 0 test scaffold (xfail stubs for all four PKG-* tests + conftest fixtures)
+  - [ ] 01-02-PLAN.md — Wave 1 pitlane-studio package scaffold (pyproject, src layout, FastAPI app + /health, click CLI on port 8001, root workspace registration) [PKG-01]
+  - [ ] 01-03-PLAN.md — Wave 1 pitlane_elo.studio_api boundary module + claude-agent-sdk <0.2.0 pin in pitlane-agent [PKG-02, PKG-03 SDK half]
+  - [ ] 01-04-PLAN.md — Wave 2 bleach safe_html Jinja2 filter + ArticleStore (SQLAlchemy Core + Pydantic + strict state machine) [PKG-03 bleach half, PKG-04]
 
 ### Phase 2: Story Angle Detection + Five-Act Data Layer
 **Goal**: The system surfaces 4–6 ranked, filtered, novel story angle candidates from any completed race using ELO signals, cross-checks driver crisis angles against actual DNF records, gates on data completeness, and has all five-act data fetched and cached — so angle quality is validated independently before the UI makes problems invisible

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,3 +1,19 @@
+---
+gsd_state_version: 1.0
+milestone: v1.0
+milestone_name: milestone
+current_phase: 1
+current_plan: None (planning not yet started)
+status: executing
+last_updated: "2026-05-02T22:23:38.618Z"
+progress:
+  total_phases: 3
+  completed_phases: 0
+  total_plans: 4
+  completed_plans: 0
+  percent: 0
+---
+
 # Project State: PitLane Studio
 
 *Last updated: 2026-05-02*
@@ -19,7 +35,7 @@
 ## Current Position
 
 **Phase:** 1 — Package Scaffold + Prerequisites
-**Status:** Not started
+**Status:** Ready to execute
 **Plans complete:** 0/?
 
 ```
@@ -82,6 +98,7 @@ Progress: [ Phase 1 ] → [ Phase 2 ] → [ Phase 3 ]
 ## Session Continuity
 
 **To resume after a break:**
+
 1. Read this file — current phase and plan are at the top
 2. Read `.planning/ROADMAP.md` — phase goals and success criteria
 3. Read `.planning/REQUIREMENTS.md` — traceability table for current phase

--- a/.planning/STATE.md
+++ b/.planning/STATE.md
@@ -1,0 +1,94 @@
+# Project State: PitLane Studio
+
+*Last updated: 2026-05-02*
+
+---
+
+## Project Reference
+
+**Core Value:** Surface 4–6 data-grounded story angles from any race and guide the journalist through an outline-first drafting pipeline, so writing time goes entirely to voice, context, and quotes — not finding the story.
+
+**Current Focus:** Phase 1 — Package Scaffold + Prerequisites
+
+**Total Phases:** 3
+**Current Phase:** 1
+**Current Plan:** None (planning not yet started)
+
+---
+
+## Current Position
+
+**Phase:** 1 — Package Scaffold + Prerequisites
+**Status:** Not started
+**Plans complete:** 0/?
+
+```
+Progress: [ Phase 1 ] → [ Phase 2 ] → [ Phase 3 ]
+             ^
+           (here)
+```
+
+---
+
+## Performance Metrics
+
+| Metric | Value |
+|--------|-------|
+| Phases total | 3 |
+| Phases complete | 0 |
+| v1 requirements | 19 |
+| Requirements mapped | 19 |
+| Requirements complete | 0 |
+
+---
+
+## Accumulated Context
+
+### Key Decisions
+
+| Decision | Rationale | Status |
+|----------|-----------|--------|
+| Separate `pitlane-studio` package | Co-authoring has a fundamentally different interaction model from the chat UI | Pending implementation |
+| Markdown copy/paste as the v1 export path | Substack unofficial API is LOW confidence; markdown is reliable and sufficient | Confirmed |
+| Substack unofficial API deferred to v2 | Cookie-based auth expires silently; adapter architecture is correct but API stability not validated | Confirmed |
+| Svelte 5 + TipTap 2.x for frontend | Drag-and-drop beat timeline and per-block prose editor require client-side state HTMX cannot cleanly manage | Pending validation |
+| Direct Python imports, not subprocess | pitlane-agent commands/ layer is pure Python and importable | Confirmed |
+| SQLite, not workspace system | Articles need stable identity and status transitions; workspaces are ephemeral | Confirmed |
+| EndureElo as signal source | Empirically outperforms SpeedElo and Bayesian model; already tested | Confirmed |
+| FiveActMapper is static config, not AI | Act→data mapping is a design choice, not a reasoning task | Confirmed |
+
+### Known Issues / Blockers
+
+- `claude-agent-sdk` is not yet pinned to `<0.2.0` — uv API drift risk (Phase 1 prerequisite)
+- Jinja2 `| safe` template outputs not yet sanitized with `bleach.clean()` — XSS risk (Phase 1 prerequisite)
+- DNF classification for 2025 data: all DNFs classified as "retired" — `exclude_mechanical_dnf` disabled; ANGL-03 uses web search cross-check specifically because of this
+- ELO thresholds for 2026 (`ΔR̂_3race > 0.5`) may need recalibration after 6+ races of data
+
+### Research Flags (Requiring Validation)
+
+- **Before Phase 2:** Substack API live endpoint — confirm `/api/v1/drafts` POST format, required cookie names, `draft_body` schema. Determines whether XPRT-02 moves to v1 or remains v2.
+- **Before Phase 3:** TipTap + Svelte 5 headless integration — verify `onMount` pattern and `getJSON()` compatibility with Substack's ProseMirror variant. MEDIUM confidence only.
+
+### Architecture Constraints (from codebase)
+
+- uv monorepo: new package lives at `packages/pitlane-studio/` following pitlane-web pattern
+- Tests run via: `uv run --directory packages/pitlane-studio pytest` (per uv-pytest skill)
+- All imports at top of file — no lazy imports inside functions or blocks (per project feedback)
+- Imports from pitlane-agent `commands/` layer, not CLI layer (pure functions, no SDK dependency)
+- No authentication, no multi-tenancy — personal tool
+
+---
+
+## Session Continuity
+
+**To resume after a break:**
+1. Read this file — current phase and plan are at the top
+2. Read `.planning/ROADMAP.md` — phase goals and success criteria
+3. Read `.planning/REQUIREMENTS.md` — traceability table for current phase
+4. Check `.planning/plans/` for any written plans (when Phase 1 planning begins)
+
+**Next action:** Run `/gsd-plan-phase 1` to create the implementation plan for Phase 1.
+
+---
+
+*State initialized: 2026-05-02*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,82 @@
+# PitLane Studio — Project Guide
+
+## Project
+
+PitLane Studio is a web-based F1 journalism co-authoring interface, added as a new `pitlane-studio` package to the existing uv monorepo (pitlane-agent + pitlane-elo + pitlane-web). It transforms ELO signal data and FastF1 race telemetry into story angle cards, five-act race timelines, and plan-then-write prose drafts with Substack markdown export.
+
+**Core value:** Surface 4–6 data-grounded story angles from any race and guide the journalist through an outline-first drafting pipeline, so writing time goes entirely to voice, context, and quotes — not finding the story.
+
+**Planning:** `.planning/` — see `ROADMAP.md`, `REQUIREMENTS.md`, `PROJECT.md`
+
+## Current Phase
+
+Phase 1: Package Scaffold + Prerequisites (Not started)
+
+Run `/gsd-progress` to check current state.
+
+## GSD Workflow
+
+This project uses the GSD (Get Shit Done) workflow. Always follow these rules:
+
+- **Before starting work:** Check `.planning/STATE.md` for current phase and context
+- **Before planning a phase:** Run `/gsd-discuss-phase <N>` to gather context
+- **Before executing:** Run `/gsd-plan-phase <N>` to create the execution plan
+- **After executing:** Run `/gsd-verify-work` to confirm requirements are met
+- **Mode:** Interactive — confirm at each major step
+
+## Monorepo Rules
+
+- **Package manager:** `uv` only — never use `pip` directly
+- **Install all packages:** `uv sync --all-packages`
+- **Run tests:** `uv run --directory packages/<package-name> pytest`
+- **Add dependency:** `uv add --directory packages/<package-name> <dep>`
+- **New package follows:** the pattern in `packages/pitlane-web/` (FastAPI + uvicorn)
+
+## Architecture
+
+```
+pitlane-studio (new)
+  └── imports from: pitlane-agent (commands/), pitlane-elo (studio_api)
+  └── does NOT use: F1Agent, workspace system, Bash tool sandboxing
+  └── own state: SQLite at ~/.pitlane/studio/articles.db
+  └── frontend: Svelte 5 + TipTap 2.x (SvelteKit static build)
+  └── API: FastAPI + uvicorn on port 8001
+```
+
+Key services to build (in dependency order):
+1. `ArticleStore` — SQLite state machine
+2. `AngleService` — ELO signals → ranked angle candidates
+3. `FiveActMapper` — static dict: acts 1-5 → pitlane-agent commands
+4. `PipelineOrchestrator` — outline → approval gate → per-beat SSE prose
+5. `SubstackExporter` — v2; adapter interface only in v1
+
+## Key Constraints
+
+- **DNF cross-check:** Use web search, NOT FastF1 classification (FastF1 DNF data unreliable)
+- **Plan-then-write:** Always 5 separate API calls (one per beat), never one long generation
+- **Hard approval gate:** Beat prose generation is blocked until outline is explicitly approved — no bypass
+- **Placeholder hooks:** Tool never fills journalist-only slots (quote, context, causal reasoning)
+- **Substack API:** LOW confidence; markdown copy/paste is the v1 export path; Substack is v2
+- **SDK pin:** `claude-agent-sdk<0.2.0` — enforce in pyproject.toml
+- **XSS:** All Jinja2 `| safe` outputs must go through `bleach.clean()`
+
+## Imports & Dependencies
+
+```python
+# Correct: import pitlane-agent commands directly
+from pitlane_agent.commands.fetch.session import get_session_info
+from pitlane_agent.commands.analyze.strategy import get_tyre_strategy
+
+# Correct: use studio_api interface
+from pitlane_elo.studio_api import detect_stories
+
+# Wrong: subprocess / CLI invocation
+# Wrong: using F1Agent for studio's pipeline
+```
+
+## Testing
+
+- Tests in `packages/pitlane-studio/tests/`
+- Cross-package integration test must call `detect_stories()` with real data (no mocks)
+- ArticleStore integration test must hit a real SQLite file (no mocks)
+- Run all tests: `uv run pytest` from repo root


### PR DESCRIPTION
## Summary

**Project:** PitLane Studio — F1 journalism co-authoring interface
**Branch type:** Project setup + planning infrastructure (pre-execution)
**Status:** Planning complete — ready to execute Phase 1

PitLane Studio is a web-based co-authoring interface for F1 journalism, built as a new `pitlane-studio` package in the existing uv monorepo. It transforms ELO signal data and FastF1 race telemetry into story angle cards, five-act race timelines, and plan-then-write prose drafts with markdown export.

This PR establishes the project foundation: project guide, v1 requirements, 3-phase roadmap, and detailed execution plans for Phase 1.

---

## Changes

### Project Setup
- `CLAUDE.md` — Project guide, monorepo rules, architecture overview, and key constraints (SDK pin, XSS policy, import style, testing patterns)
- `.planning/PROJECT.md` — What PitLane Studio is, core value proposition, validated/active requirements, key decisions log
- `.planning/REQUIREMENTS.md` — 19 v1 requirements across 5 capability areas (PKG, ANGL, ACT, PTW, UI, XPRT) with full traceability

### Roadmap (3 phases)
- `.planning/ROADMAP.md` — 3-phase roadmap with goals, success criteria, and requirement mapping
  - **Phase 1:** Package Scaffold + Prerequisites (PKG-01–04)
  - **Phase 2:** Story Angle Detection + Five-Act Data Layer (ANGL-01–04, ACT-01–02)
  - **Phase 3:** Plan-Then-Write Pipeline + Co-Authoring UI (ACT-03, PTW-01–04, UI-01–03, XPRT-01)
- `.planning/STATE.md` — Current project state with key decisions and known blockers

### Phase 1 Execution Plans
Phase 1 is planned in 4 sequential waves:

| Plan | Wave | Scope |
|------|------|-------|
| 01-01 | 0 | Test scaffold — xfail stubs for all PKG-* tests + conftest fixtures |
| 01-02 | 1 | pitlane-studio package: pyproject, src layout, FastAPI `/health`, click CLI on port 8001 |
| 01-03 | 1 | `pitlane_elo.studio_api` boundary module + `claude-agent-sdk<0.2.0` pin |
| 01-04 | 2 | `bleach` safe_html Jinja2 filter + `ArticleStore` (SQLAlchemy Core + Pydantic + strict state machine) |

---

## Requirements Addressed

| Req | Description |
|-----|-------------|
| PKG-01 | pitlane-studio as uv workspace package with FastAPI skeleton + CLI |
| PKG-02 | `pitlane_elo.studio_api` exposes `detect_stories()` with real-data integration test |
| PKG-03 | `claude-agent-sdk<0.2.0` pin + Jinja2 `\| safe` sanitized with `bleach.clean()` |
| PKG-04 | SQLite article store at `~/.pitlane/studio/articles.db` with 4-state machine |

---

## Key Decisions

| Decision | Rationale |
|----------|-----------|
| `detect_stories(year, round) -> list[StorySignal]` | Returns existing StorySignal type as-is; Phase 2 AngleService handles transformation |
| SQLAlchemy Core (not ORM) | First DB layer in monorepo; Core is sufficient for a single 4-state table |
| Pydantic BaseModel for article records | Already a FastAPI dep; no new dependency |
| Invalid state transitions raise `ValueError` | Hard approval gate in Phase 3 depends on strict enforcement |
| Integration test uses latest available 2026 race | Dynamic, not hardcoded — passes on any machine with cached 2026 data |
| bleach.clean() scope is pitlane-studio only | Existing pitlane-web `\| safe` usages are out of Phase 1 scope |
| Markdown copy/paste as v1 export path | Substack unofficial API is low confidence; markdown is reliable and sufficient |
| Svelte 5 + TipTap 2.x for frontend | Client-side state required for drag-and-drop beat timeline and per-block prose editor |

---

## Verification

- [ ] Automated verification: N/A — planning/setup PR (Phase 1 not yet executed)
- [ ] Reviewer: confirm CLAUDE.md constraints match intended project architecture
- [ ] Reviewer: confirm 3-phase roadmap covers all 19 v1 requirements

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)